### PR TITLE
Add FastAPI backend with Nginx reverse proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+
+# Node
+node_modules/
+
+# Build artifacts
+MCP_119/frontend/home/build/

--- a/MCP_119/README.md
+++ b/MCP_119/README.md
@@ -5,11 +5,19 @@ This directory contains the `docker-compose.yaml` file that sets up the followin
 - **Ollama** - running in the `ollama/ollama` container.
 - **pgAdmin** - graphical interface for PostgreSQL using `dpage/pgadmin4`.
 - **PostgreSQL** - with PostGIS support using the `postgis/postgis:15-3.4` image.
+- **FastAPI** - simple API server.
+- **Nginx** - reverse proxy exposing the API under `/api/`.
 
 Start the stack:
 
 ```bash
 docker compose up -d
+```
+
+Before running the stack for the first time, build the React application so Nginx can serve the static files:
+
+```bash
+(cd frontend/home && npm install && npm run build)
 ```
 
 Stop the stack:

--- a/MCP_119/backend/Dockerfile
+++ b/MCP_119/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/MCP_119/backend/main.py
+++ b/MCP_119/backend/main.py
@@ -1,0 +1,26 @@
+from fastapi import FastAPI, WebSocket
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+@app.get("/hello")
+async def read_root():
+    return {"message": "Hello from FastAPI"}
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    try:
+        while True:
+            data = await websocket.receive_text()
+            await websocket.send_text(f"Message text was: {data}")
+    except Exception:
+        await websocket.close()

--- a/MCP_119/backend/requirements.txt
+++ b/MCP_119/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]

--- a/MCP_119/docker-compose.yaml
+++ b/MCP_119/docker-compose.yaml
@@ -30,5 +30,23 @@ services:
     ports:
       - "11434:11434"
 
+  fastapi:
+    build:
+      context: ./backend
+    container_name: fastapi
+    ports:
+      - "8000:8000"
+
+  nginx:
+    image: nginx:alpine
+    container_name: nginx
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./frontend/home/build:/usr/share/nginx/html:ro
+    ports:
+      - "80:80"
+    depends_on:
+      - fastapi
+
 volumes:
   postgres_data:

--- a/MCP_119/nginx/default.conf
+++ b/MCP_119/nginx/default.conf
@@ -1,0 +1,21 @@
+server {
+    listen 80;
+
+    location /api/ {
+        proxy_pass http://fastapi:8000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebSocket support
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri $uri/ =404;
+    }
+}


### PR DESCRIPTION
## Summary
- add backend service using FastAPI with CORS and websocket support
- configure Nginx reverse proxy so `/api/` points at FastAPI
- include Dockerfiles and compose updates
- update README with instructions

## Testing
- `python3 -m py_compile MCP_119/backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6865588bcb0083238de513731230a6f2