### PR TITLE
Implement query API

### DIFF
--- a/MCP_119/backend/main.py
+++ b/MCP_119/backend/main.py
@@ -1,4 +1,7 @@
+from uuid import uuid4
+
 from fastapi import FastAPI, WebSocket
+from pydantic import BaseModel
 from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI()
@@ -10,6 +13,10 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+class QueryRequest(BaseModel):
+    query: str
 
 @app.get("/hello")
 async def read_root():
@@ -24,3 +31,15 @@ async def websocket_endpoint(websocket: WebSocket):
             await websocket.send_text(f"Message text was: {data}")
     except Exception:
         await websocket.close()
+
+
+@app.post("/query")
+async def handle_query(request: QueryRequest):
+    """Receive a user query and wrap it in JSON-RPC format."""
+    rpc_payload = {
+        "jsonrpc": "2.0",
+        "method": "query",
+        "params": {"query": request.query},
+        "id": str(uuid4()),
+    }
+    return rpc_payload


### PR DESCRIPTION
## Summary
- add POST `/query` FastAPI route
- wrap incoming user query in a JSON-RPC request payload

## Testing
- `python -m py_compile MCP_119/backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68655ee64a0083239d88f012bdd8c129