### PR TITLE
Add /api/query alias

### DIFF
--- a/MCP_119/backend/main.py
+++ b/MCP_119/backend/main.py
@@ -34,6 +34,7 @@ async def websocket_endpoint(websocket: WebSocket):
 
 
 @app.post("/query")
+@app.post("/api/query")
 async def handle_query(request: QueryRequest):
     """Receive a user query and wrap it in JSON-RPC format."""
     rpc_payload = {


### PR DESCRIPTION
## Summary
- expose `/api/query` in FastAPI for consistency with frontend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d2024824832380eefed7cd84d16d