### PR TITLE
Implement JSON-RPC request/response helpers

### DIFF
--- a/MCP_119/backend/jsonrpc.py
+++ b/MCP_119/backend/jsonrpc.py
@@ -1,0 +1,29 @@
+"""Utility functions for JSON-RPC 2.0 message creation."""
+from typing import Any, Dict, Optional
+from uuid import uuid4
+
+JSON_RPC_VERSION = "2.0"
+
+def build_request(method: str, params: Optional[Dict[str, Any]] | None = None, id: Optional[str] | None = None) -> Dict[str, Any]:
+    """Create a JSON-RPC request object."""
+    if id is None:
+        id = str(uuid4())
+    return {
+        "jsonrpc": JSON_RPC_VERSION,
+        "method": method,
+        "params": params or {},
+        "id": id,
+    }
+
+
+def build_response(result: Any | None = None, id: Optional[str] | None = None, error: Optional[Dict[str, Any]] | None = None) -> Dict[str, Any]:
+    """Create a JSON-RPC response object with either result or error."""
+    response = {
+        "jsonrpc": JSON_RPC_VERSION,
+        "id": id,
+    }
+    if error is not None:
+        response["error"] = error
+    else:
+        response["result"] = result
+    return response

--- a/MCP_119/backend/main.py
+++ b/MCP_119/backend/main.py
@@ -1,8 +1,7 @@
-from uuid import uuid4
-
 from fastapi import FastAPI, WebSocket
 from pydantic import BaseModel
 from fastapi.middleware.cors import CORSMiddleware
+from . import jsonrpc
 
 app = FastAPI()
 
@@ -37,10 +36,8 @@ async def websocket_endpoint(websocket: WebSocket):
 @app.post("/api/query")
 async def handle_query(request: QueryRequest):
     """Receive a user query and wrap it in JSON-RPC format."""
-    rpc_payload = {
-        "jsonrpc": "2.0",
-        "method": "query",
-        "params": {"query": request.query},
-        "id": str(uuid4()),
-    }
+    rpc_payload = jsonrpc.build_request(
+        method="query",
+        params={"query": request.query},
+    )
     return rpc_payload


### PR DESCRIPTION
## Summary
- add `jsonrpc.py` helper for JSON-RPC 2.0 formatting
- use helper to construct payload in FastAPI endpoint

## Testing
- `python -m py_compile MCP_119/backend/jsonrpc.py MCP_119/backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6865d365b2ac832384ac428b50824d57