### PR TITLE
Add model router with tests

### DIFF
--- a/MCP_119/backend/main.py
+++ b/MCP_119/backend/main.py
@@ -2,8 +2,10 @@ from fastapi import FastAPI, WebSocket
 from pydantic import BaseModel
 from fastapi.middleware.cors import CORSMiddleware
 from . import jsonrpc
+from .model_router import ModelRouter
 
 app = FastAPI()
+router = ModelRouter()
 
 app.add_middleware(
     CORSMiddleware,
@@ -16,6 +18,11 @@ app.add_middleware(
 
 class QueryRequest(BaseModel):
     query: str
+
+
+class ModelRequest(BaseModel):
+    task_type: str | None = None
+    user_id: str | None = None
 
 @app.get("/hello")
 async def read_root():
@@ -41,3 +48,11 @@ async def handle_query(request: QueryRequest):
         params={"query": request.query},
     )
     return rpc_payload
+
+
+@app.post("/model")
+@app.post("/api/model")
+async def select_model(request: ModelRequest):
+    """Select a model based on user or task information."""
+    model_name = router.route(task_type=request.task_type, user_id=request.user_id)
+    return {"model": model_name}

--- a/MCP_119/backend/model_router.py
+++ b/MCP_119/backend/model_router.py
@@ -1,0 +1,28 @@
+from typing import Dict, Optional
+
+
+class ModelRouter:
+    """Simple router that selects a model based on user or task type."""
+
+    def __init__(self) -> None:
+        # Mapping of task types to model names
+        self.task_mapping: Dict[str, str] = {
+            "nlp": "phi3-3.8b",
+            "code": "Qwen2.5-coder-7b",
+            "sql": "sqlcoder-7b",
+        }
+        # Optional user specific preferences
+        self.user_mapping: Dict[str, str] = {}
+
+    def add_user_preference(self, user_id: str, model_name: str) -> None:
+        """Record a preferred model for a specific user."""
+        self.user_mapping[user_id] = model_name
+
+    def route(self, *, task_type: Optional[str] = None, user_id: Optional[str] = None) -> str:
+        """Return the model name based on provided information."""
+        if user_id and user_id in self.user_mapping:
+            return self.user_mapping[user_id]
+        if task_type and task_type in self.task_mapping:
+            return self.task_mapping[task_type]
+        # Default model if nothing matches
+        return self.task_mapping["nlp"]

--- a/MCP_119/tests/test_model_router.py
+++ b/MCP_119/tests/test_model_router.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "backend")))
+from model_router import ModelRouter
+
+
+def test_task_type_routing():
+    router = ModelRouter()
+    assert router.route(task_type="code") == "Qwen2.5-coder-7b"
+
+
+def test_user_preference_routing():
+    router = ModelRouter()
+    router.add_user_preference("alice", "custom-model")
+    assert router.route(user_id="alice") == "custom-model"


### PR DESCRIPTION
## Summary
- add `ModelRouter` to select models based on user or task type
- expose new `/model` endpoint in FastAPI app
- make `backend` a package and add a unit test

## Testing
- `pytest -q MCP_119/tests/test_model_router.py`

------
https://chatgpt.com/codex/tasks/task_e_6865d4212ce88323bebebe6d6d488131