### PR TITLE
Add prompt template loader

### DIFF
--- a/MCP_119/backend/main.py
+++ b/MCP_119/backend/main.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 from fastapi.middleware.cors import CORSMiddleware
 from . import jsonrpc
 from .model_router import ModelRouter
+from . import prompt_templates
 
 app = FastAPI()
 router = ModelRouter()
@@ -23,6 +24,12 @@ class QueryRequest(BaseModel):
 class ModelRequest(BaseModel):
     task_type: str | None = None
     user_id: str | None = None
+
+
+class PromptRequest(BaseModel):
+    model: str
+    task: str
+    query: str
 
 @app.get("/hello")
 async def read_root():
@@ -56,3 +63,12 @@ async def select_model(request: ModelRequest):
     """Select a model based on user or task information."""
     model_name = router.route(task_type=request.task_type, user_id=request.user_id)
     return {"model": model_name}
+
+
+@app.post("/prompt")
+@app.post("/api/prompt")
+async def build_prompt(request: PromptRequest):
+    """Return a prompt with the user's query filled in."""
+    template = prompt_templates.load_template(request.model, request.task)
+    prompt = prompt_templates.fill_template(template, request.query)
+    return {"prompt": prompt}

--- a/MCP_119/backend/prompt_templates.py
+++ b/MCP_119/backend/prompt_templates.py
@@ -1,0 +1,25 @@
+"""Utility functions to manage prompt templates."""
+from typing import Dict
+
+# Nested mapping of model name to task to prompt template
+PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
+    "phi3-3.8b": {
+        "nlp": "Answer the following question: {query}",
+    },
+    "Qwen2.5-coder-7b": {
+        "code": "Provide code to accomplish the task: {query}",
+    },
+    "sqlcoder-7b": {
+        "sql": "Write an SQL query for: {query}",
+    },
+}
+
+
+def load_template(model: str, task: str) -> str:
+    """Return the prompt template for a given model and task."""
+    return PROMPT_TEMPLATES.get(model, {}).get(task, "{query}")
+
+
+def fill_template(template: str, query: str) -> str:
+    """Insert the user's query into the template."""
+    return template.format(query=query)

--- a/MCP_119/tests/test_prompt_templates.py
+++ b/MCP_119/tests/test_prompt_templates.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "backend")))
+
+from prompt_templates import load_template, fill_template
+
+
+def test_load_template():
+    template = load_template("phi3-3.8b", "nlp")
+    assert template == "Answer the following question: {query}"
+
+
+def test_fill_template():
+    template = "Hello {query}"
+    result = fill_template(template, "world")
+    assert result == "Hello world"


### PR DESCRIPTION
## Summary
- add utilities for prompt templates
- expose new `/api/prompt` endpoint
- test prompt template helper functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d4fde5448323a6a48db2338fbdb9