### PR TITLE
Add SQL generation endpoint

### DIFF
--- a/MCP_119/backend/main.py
+++ b/MCP_119/backend/main.py
@@ -5,6 +5,7 @@ from . import jsonrpc
 from .model_router import ModelRouter
 from . import prompt_templates
 from .context_manager import ConversationContext
+from . import sql_generator
 
 app = FastAPI()
 router = ModelRouter()
@@ -38,6 +39,10 @@ class RecordRequest(BaseModel):
     user_id: str
     query: str
     response: str
+
+
+class SQLRequest(BaseModel):
+    question: str
 
 @app.get("/hello")
 async def read_root():
@@ -104,3 +109,11 @@ async def get_summary(user_id: str):
     """Return a summary of the conversation history for a user."""
     summary = context_manager.summarize(user_id)
     return {"summary": summary}
+
+
+@app.post("/sql")
+@app.post("/api/sql")
+async def generate_sql(request: SQLRequest):
+    """Generate an SQL query (including PostGIS syntax) using an LLM."""
+    sql = sql_generator.generate_sql(request.question)
+    return {"sql": sql}

--- a/MCP_119/backend/sql_generator.py
+++ b/MCP_119/backend/sql_generator.py
@@ -1,0 +1,27 @@
+import json
+from urllib import request as urlrequest
+import prompt_templates
+import model_router
+
+
+OLLAMA_URL = "http://localhost:11434/api/generate"
+
+
+def generate_sql(question: str, *, model: str | None = None) -> str:
+    """Generate an SQL query from a natural language question using an LLM."""
+    if model is None:
+        model = model_router.ModelRouter().route(task_type="sql")
+
+    template = prompt_templates.load_template(model, "sql")
+    prompt = prompt_templates.fill_template(template, question)
+
+    req = urlrequest.Request(
+        OLLAMA_URL,
+        data=json.dumps({"model": model, "prompt": prompt}).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urlrequest.urlopen(req) as resp:
+        data = json.load(resp)
+    sql = data.get("response", "")
+    return sql.strip()

--- a/MCP_119/tests/test_sql_generator.py
+++ b/MCP_119/tests/test_sql_generator.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "backend")))
+
+from urllib import request as urlrequest
+import json
+import sql_generator
+
+
+class FakeResponse:
+    def __init__(self, data: bytes):
+        self.data = data
+
+    def read(self):
+        return self.data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+
+def test_generate_sql(monkeypatch):
+    def fake_urlopen(req):
+        return FakeResponse(json.dumps({"response": "SELECT 1;"}).encode())
+
+    monkeypatch.setattr(urlrequest, "urlopen", fake_urlopen)
+    sql = sql_generator.generate_sql("test question")
+    assert sql == "SELECT 1;"


### PR DESCRIPTION
## Summary
- add `sql_generator` module to produce SQL queries via Ollama
- expose `/sql` API in backend `main.py`
- add test for SQL generation helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d69f5f308323906241aa40d2390e