### PR TITLE
Implement frontend result display and error handling

### DIFF
--- a/MCP_119/frontend/home/src/App.css
+++ b/MCP_119/frontend/home/src/App.css
@@ -29,3 +29,18 @@
 .error {
   color: red;
 }
+
+.result-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.result-table th,
+.result-table td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+}
+
+.result-table th {
+  background-color: #f0f0f0;
+}

--- a/MCP_119/frontend/home/src/App.js
+++ b/MCP_119/frontend/home/src/App.js
@@ -9,21 +9,32 @@ function App() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!query.trim()) return;
+    if (!query.trim()) {
+      setError('請輸入查詢內容');
+      return;
+    }
     setLoading(true);
     setError(null);
     setResult(null);
     try {
-      const response = await fetch('/api/query', {
+      const response = await fetch('/api/sql/execute', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ query })
       });
       if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        if (data && data.error) {
+          throw new Error(data.error.message || 'Server error');
+        }
         throw new Error('Network response was not ok');
       }
       const data = await response.json();
-      setResult(data);
+      if (data.error) {
+        setError(data.error.message || 'Server error');
+      } else {
+        setResult(data.result ?? data);
+      }
     } catch (err) {
       setError(err.message);
     } finally {
@@ -47,7 +58,28 @@ function App() {
       </form>
       <div className="query-result">
         {error && <p className="error">{error}</p>}
-        {result && <pre>{JSON.stringify(result, null, 2)}</pre>}
+        {Array.isArray(result) ? (
+          <table className="result-table">
+            <thead>
+              <tr>
+                {Object.keys(result[0] || {}).map((key) => (
+                  <th key={key}>{key}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {result.map((row, idx) => (
+                <tr key={idx}>
+                  {Object.values(row).map((val, i) => (
+                    <td key={i}>{String(val)}</td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          result && <pre>{JSON.stringify(result, null, 2)}</pre>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- enhance React frontend to handle empty queries, server errors and parse JSON
- render SQL results in a table for readability

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865dad0400c8323b9baedb0c3724ee8