### PR TITLE
Implement prompt history injection

### DIFF
--- a/MCP_119/backend/prompt_templates.py
+++ b/MCP_119/backend/prompt_templates.py
@@ -23,3 +23,13 @@ def load_template(model: str, task: str) -> str:
 def fill_template(template: str, query: str) -> str:
     """Insert the user's query into the template."""
     return template.format(query=query)
+
+
+def build_prompt_with_history(model: str, task: str, query: str, history: list) -> str:
+    """Return a prompt that includes conversation history followed by the user's query."""
+    template = load_template(model, task)
+    base_prompt = fill_template(template, query)
+    if not history:
+        return base_prompt
+    history_text = "\n".join(f"{m.role}: {m.content}" for m in history)
+    return f"{history_text}\n{base_prompt}"

--- a/MCP_119/tests/test_prompt_context_integration.py
+++ b/MCP_119/tests/test_prompt_context_integration.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "backend")))
+
+from prompt_templates import build_prompt_with_history
+from context_manager import ConversationContext
+
+
+def test_build_prompt_with_history():
+    ctx = ConversationContext()
+    ctx.record("alice", "hi", "hello")
+    ctx.record("alice", "how are you", "fine")
+    history = ctx.get_history("alice")
+    prompt = build_prompt_with_history("phi3-3.8b", "nlp", "what's up?", history)
+    assert "user: hi" in prompt
+    assert "assistant: hello" in prompt
+    assert "what's up?" in prompt


### PR DESCRIPTION
## Summary
- support building prompts that include conversation history
- test integration between prompt templates and context manager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865e17231a08323bb8d2a24c8320f56