### PR TITLE
Implement SQLite conversation context

### DIFF
--- a/MCP_119/tests/test_context_manager.py
+++ b/MCP_119/tests/test_context_manager.py
@@ -7,7 +7,7 @@ from context_manager import ConversationContext
 
 
 def test_record_and_history():
-    ctx = ConversationContext()
+    ctx = ConversationContext(db_path=":memory:")
     ctx.record("alice", "hi", "hello")
     history = ctx.get_history("alice")
     assert len(history) == 2
@@ -16,7 +16,7 @@ def test_record_and_history():
 
 
 def test_summary():
-    ctx = ConversationContext()
+    ctx = ConversationContext(db_path=":memory:")
     for i in range(3):
         ctx.record("bob", f"q{i}", f"a{i}")
     summary = ctx.summarize("bob", max_chars=50)

--- a/MCP_119/tests/test_prompt_context_integration.py
+++ b/MCP_119/tests/test_prompt_context_integration.py
@@ -8,7 +8,7 @@ from context_manager import ConversationContext
 
 
 def test_build_prompt_with_history():
-    ctx = ConversationContext()
+    ctx = ConversationContext(db_path=":memory:")
     ctx.record("alice", "hi", "hello")
     ctx.record("alice", "how are you", "fine")
     history = ctx.get_history("alice")


### PR DESCRIPTION
## Summary
- store conversation history in SQLite instead of memory
- adjust tests to use an in-memory database for speed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865e29eaa488323b0b76c20a6ea50a5