### PR TITLE
Implement context reset and retrieval endpoints

### DIFF
--- a/MCP_119/backend/context_manager.py
+++ b/MCP_119/backend/context_manager.py
@@ -66,5 +66,13 @@ class ConversationContext:
         text = " ".join(f"{m.role}: {m.content}" for m in messages)
         return shorten(text, width=max_chars, placeholder="...")
 
+    def reset(self, user_id: str) -> None:
+        """Clear all stored messages for the given user."""
+        with self._conn:
+            self._conn.execute(
+                "DELETE FROM messages WHERE user_id=?",
+                (user_id,),
+            )
+
     def close(self) -> None:
         self._conn.close()

--- a/MCP_119/backend/main.py
+++ b/MCP_119/backend/main.py
@@ -43,6 +43,14 @@ class RecordRequest(BaseModel):
     response: str
 
 
+class RetrieveRequest(BaseModel):
+    user_id: str
+
+
+class ResetRequest(BaseModel):
+    user_id: str
+
+
 class SQLRequest(BaseModel):
     question: str
 
@@ -99,6 +107,22 @@ async def build_prompt(request: PromptRequest):
 async def record_interaction(request: RecordRequest):
     """Record a user query and response in the conversation context."""
     context_manager.record(request.user_id, request.query, request.response)
+    return {"status": "ok"}
+
+
+@app.post("/context/retrieve")
+@app.post("/api/context/retrieve")
+async def retrieve_history(request: RetrieveRequest):
+    """Retrieve the conversation history for a user."""
+    messages = context_manager.get_history(request.user_id)
+    return {"history": [m.__dict__ for m in messages]}
+
+
+@app.post("/context/reset")
+@app.post("/api/context/reset")
+async def reset_history(request: ResetRequest):
+    """Delete all conversation history for a user."""
+    context_manager.reset(request.user_id)
     return {"status": "ok"}
 
 

--- a/MCP_119/tests/test_context_manager.py
+++ b/MCP_119/tests/test_context_manager.py
@@ -22,3 +22,11 @@ def test_summary():
     summary = ctx.summarize("bob", max_chars=50)
     assert isinstance(summary, str)
     assert len(summary) <= 50
+
+
+def test_reset():
+    ctx = ConversationContext(db_path=":memory:")
+    ctx.record("carol", "hi", "hello")
+    ctx.reset("carol")
+    history = ctx.get_history("carol")
+    assert history == []


### PR DESCRIPTION
## Summary
- implement `reset` method in the SQLite-backed `ConversationContext`
- add `RetrieveRequest` and `ResetRequest` models
- create `/context/retrieve` and `/context/reset` FastAPI endpoints
- test reset functionality in the context manager

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865e62332408323831c9e9058f307e7