### PR TITLE
Update model names

### DIFF
--- a/MCP_119/backend/model_router.py
+++ b/MCP_119/backend/model_router.py
@@ -7,11 +7,11 @@ class ModelRouter:
     def __init__(self) -> None:
         # Mapping of task types to model names
         self.task_mapping: Dict[str, str] = {
-            # Qwen2.5-coder-7b handles user facing responses
-            "nlp": "Qwen2.5-coder-7b",
+            # qwen2.5-coder:7b handles user facing responses
+            "nlp": "qwen2.5-coder:7b",
             # All three models generate SQL queries
-            "code": "phi3-3.8b",
-            "sql": "sqlcoder-7b",
+            "code": "phi3:3.8b",
+            "sql": "sqlcoder:7b",
         }
         # Optional user specific preferences
         self.user_mapping: Dict[str, str] = {}

--- a/MCP_119/backend/prompt_templates.py
+++ b/MCP_119/backend/prompt_templates.py
@@ -4,15 +4,15 @@ from typing import Dict
 # Nested mapping of model name to task to prompt template
 PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
     # All models now share the same SQL template
-    "phi3-3.8b": {
+    "phi3:3.8b": {
         "sql": "Write an SQL query for: {query}",
     },
-    "Qwen2.5-coder-7b": {
+    "qwen2.5-coder:7b": {
         # Used for SQL generation and human friendly responses
         "sql": "Write an SQL query for: {query}",
         "nlp": "Answer the following question: {query}",
     },
-    "sqlcoder-7b": {
+    "sqlcoder:7b": {
         "sql": "Write an SQL query for: {query}",
     },
 }

--- a/MCP_119/tests/test_model_router.py
+++ b/MCP_119/tests/test_model_router.py
@@ -7,7 +7,7 @@ from model_router import ModelRouter
 
 def test_task_type_routing():
     router = ModelRouter()
-    assert router.route(task_type="code") == "phi3-3.8b"
+    assert router.route(task_type="code") == "phi3:3.8b"
 
 
 def test_user_preference_routing():

--- a/MCP_119/tests/test_model_router_list.py
+++ b/MCP_119/tests/test_model_router_list.py
@@ -9,5 +9,5 @@ def test_list_models():
     router = ModelRouter()
     router.add_user_preference("alice", "custom-model")
     models = router.list_models()
-    assert set(models) == {"phi3-3.8b", "Qwen2.5-coder-7b", "sqlcoder-7b", "custom-model"}
+    assert set(models) == {"phi3:3.8b", "qwen2.5-coder:7b", "sqlcoder:7b", "custom-model"}
 

--- a/MCP_119/tests/test_prompt_context_integration.py
+++ b/MCP_119/tests/test_prompt_context_integration.py
@@ -12,7 +12,7 @@ def test_build_prompt_with_history():
     ctx.record("alice", "hi", "hello")
     ctx.record("alice", "how are you", "fine")
     history = ctx.get_history("alice")
-    prompt = build_prompt_with_history("Qwen2.5-coder-7b", "nlp", "what's up?", history)
+    prompt = build_prompt_with_history("qwen2.5-coder:7b", "nlp", "what's up?", history)
     assert "user: hi" in prompt
     assert "assistant: hello" in prompt
     assert "what's up?" in prompt

--- a/MCP_119/tests/test_prompt_templates.py
+++ b/MCP_119/tests/test_prompt_templates.py
@@ -7,7 +7,7 @@ from prompt_templates import load_template, fill_template
 
 
 def test_load_template():
-    template = load_template("Qwen2.5-coder-7b", "nlp")
+    template = load_template("qwen2.5-coder:7b", "nlp")
     assert template == "Answer the following question: {query}"
 
 


### PR DESCRIPTION
## Summary
- rename models to qwen2.5-coder:7b, phi3:3.8b and sqlcoder:7b
- adjust backend routing and templates accordingly
- update tests for new model names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865ee31c8cc8323ac06102f59d95d9d