### PR TITLE
Fix backend build error

### DIFF
--- a/MCP_119/backend/Dockerfile
+++ b/MCP_119/backend/Dockerfile
@@ -2,5 +2,7 @@ FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY main.py .
+
+# Copy the rest of the application source code
+COPY . .
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- copy all backend modules in Dockerfile so that `jsonrpc` is found

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865f9696fc88323b3ff2949b0d5ae68