### PR TITLE
Fix dev server API proxy

### DIFF
--- a/MCP_119/frontend/home/package.json
+++ b/MCP_119/frontend/home/package.json
@@ -2,6 +2,7 @@
   "name": "home",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:8000",
   "dependencies": {
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",


### PR DESCRIPTION
## Summary
- enable frontend proxy to FastAPI so `/api` endpoints work during `npm start`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866181ef0948323b83d733675f3eb3f