### PR TITLE
Fix SQL generation validation

### DIFF
--- a/MCP_119/backend/main.py
+++ b/MCP_119/backend/main.py
@@ -161,7 +161,10 @@ async def get_summary(user_id: str):
 @app.post("/api/sql")
 async def generate_sql(request: SQLRequest):
     """Generate an SQL query (including PostGIS syntax) using an LLM."""
-    sql = sql_generator.generate_sql(request.question)
+    try:
+        sql = sql_generator.generate_sql(request.question)
+    except ValueError as exc:
+        return {"error": str(exc)}
     return {"sql": sql}
 
 

--- a/MCP_119/backend/sql_generator.py
+++ b/MCP_119/backend/sql_generator.py
@@ -1,10 +1,19 @@
 import json
+import re
 from urllib import request as urlrequest
 import prompt_templates
 import model_router
 
 
 OLLAMA_URL = "http://localhost:11434/api/generate"
+
+
+SQL_START = re.compile(r"^(SELECT|INSERT|UPDATE|DELETE|CREATE|DROP|WITH)\b", re.IGNORECASE)
+
+
+def _is_valid_sql(sql: str) -> bool:
+    """Return True if the string appears to be a valid SQL statement."""
+    return bool(SQL_START.match(sql))
 
 
 def generate_sql(question: str, *, model: str | None = None) -> str:
@@ -23,5 +32,7 @@ def generate_sql(question: str, *, model: str | None = None) -> str:
     )
     with urlrequest.urlopen(req) as resp:
         data = json.load(resp)
-    sql = data.get("response", "")
-    return sql.strip()
+    sql = data.get("response", "").strip()
+    if not _is_valid_sql(sql):
+        raise ValueError(f"Generated text is not valid SQL: {sql}")
+    return sql

--- a/MCP_119/tests/test_sql_generator.py
+++ b/MCP_119/tests/test_sql_generator.py
@@ -6,6 +6,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..",
 from urllib import request as urlrequest
 import json
 import sql_generator
+import pytest
 
 
 class FakeResponse:
@@ -29,3 +30,12 @@ def test_generate_sql(monkeypatch):
     monkeypatch.setattr(urlrequest, "urlopen", fake_urlopen)
     sql = sql_generator.generate_sql("test question")
     assert sql == "SELECT 1;"
+
+
+def test_generate_sql_invalid(monkeypatch):
+    def fake_urlopen(req):
+        return FakeResponse(json.dumps({"response": "列出前五筆資料"}).encode())
+
+    monkeypatch.setattr(urlrequest, "urlopen", fake_urlopen)
+    with pytest.raises(ValueError):
+        sql_generator.generate_sql("bad question")


### PR DESCRIPTION
## Summary
- detect invalid SQL text from LLM and raise an error
- return error from `/api/sql` when generated SQL is invalid
- test sql generator validation logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_686620de44e0832392e6c4ffa00ef9f9