### PR TITLE
Fix Ollama connection

### DIFF
--- a/MCP_119/README.md
+++ b/MCP_119/README.md
@@ -12,6 +12,11 @@ The `fastapi` service connects to the PostgreSQL container using environment
 variables defined in `docker-compose.yaml`. If you need to customise the
 database credentials, update these variables accordingly.
 
+The API container also communicates with the Ollama service. By default the
+backend expects Ollama to be reachable at `http://localhost:11434`. When using
+Docker Compose, the `OLLAMA_URL` environment variable is set so the backend
+calls the `ollama` container instead.
+
 Start the stack:
 
 ```bash

--- a/MCP_119/backend/sql_generator.py
+++ b/MCP_119/backend/sql_generator.py
@@ -1,11 +1,12 @@
 import json
+import os
 import re
 from urllib import request as urlrequest
 import prompt_templates
 import model_router
 
 
-OLLAMA_URL = "http://localhost:11434/api/generate"
+OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434/api/generate")
 
 
 SQL_START = re.compile(r"^(SELECT|INSERT|UPDATE|DELETE|CREATE|DROP|WITH)\b", re.IGNORECASE)

--- a/MCP_119/docker-compose.yaml
+++ b/MCP_119/docker-compose.yaml
@@ -42,6 +42,7 @@ services:
       DB_NAME: mydb
       DB_USER: user
       DB_PASSWORD: 123456
+      OLLAMA_URL: http://ollama:11434/api/generate
     ports:
       - "8000:8000"
     depends_on:


### PR DESCRIPTION
## Summary
- allow configuring the Ollama service URL via `OLLAMA_URL`
- set that variable for the FastAPI container
- document the new environment variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68662cc884288323aa23f250548f0558