### PR TITLE
Fix parsing of streaming JSON from LLM

### DIFF
--- a/MCP_119/tests/test_sql_generator.py
+++ b/MCP_119/tests/test_sql_generator.py
@@ -39,3 +39,17 @@ def test_generate_sql_invalid(monkeypatch):
     monkeypatch.setattr(urlrequest, "urlopen", fake_urlopen)
     with pytest.raises(ValueError):
         sql_generator.generate_sql("bad question")
+
+
+def test_generate_sql_streaming(monkeypatch):
+    data = "\n".join([
+        json.dumps({"response": "SELECT ", "done": False}),
+        json.dumps({"response": "1;", "done": True}),
+    ])
+
+    def fake_urlopen(req):
+        return FakeResponse(data.encode())
+
+    monkeypatch.setattr(urlrequest, "urlopen", fake_urlopen)
+    sql = sql_generator.generate_sql("question")
+    assert sql == "SELECT 1;"


### PR DESCRIPTION
## Summary
- handle newline-delimited JSON in `generate_sql`
- add regression test for streaming JSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686641492c6c8323be2cb4d56639b5bd