### PR TITLE
Enhance SQL prompts with schema info

### DIFF
--- a/MCP_119/backend/prompt_templates.py
+++ b/MCP_119/backend/prompt_templates.py
@@ -5,15 +5,24 @@ from typing import Dict
 PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
     # All models now share the same SQL template
     "phi3:3.8b": {
-        "sql": "Write an SQL query for: {query}",
+        "sql": (
+            "Given the database schema:\n{schema}\n"
+            "Write an SQL query for: {query}"
+        ),
     },
     "qwen2.5-coder:7b": {
         # Used for SQL generation and human friendly responses
-        "sql": "Write an SQL query for: {query}",
+        "sql": (
+            "Given the database schema:\n{schema}\n"
+            "Write an SQL query for: {query}"
+        ),
         "nlp": "Answer the following question: {query}",
     },
     "sqlcoder:7b": {
-        "sql": "Write an SQL query for: {query}",
+        "sql": (
+            "Given the database schema:\n{schema}\n"
+            "Write an SQL query for: {query}"
+        ),
     },
 }
 
@@ -23,9 +32,9 @@ def load_template(model: str, task: str) -> str:
     return PROMPT_TEMPLATES.get(model, {}).get(task, "{query}")
 
 
-def fill_template(template: str, query: str) -> str:
-    """Insert the user's query into the template."""
-    return template.format(query=query)
+def fill_template(template: str, query: str, **extra: str) -> str:
+    """Insert the user's query and any extra data into the template."""
+    return template.format(query=query, **extra)
 
 
 def build_prompt_with_history(model: str, task: str, query: str, history: list) -> str:

--- a/MCP_119/backend/sql_generator.py
+++ b/MCP_119/backend/sql_generator.py
@@ -4,6 +4,7 @@ import re
 from urllib import request as urlrequest
 import prompt_templates
 import model_router
+import database
 
 
 OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434/api/generate")
@@ -23,7 +24,8 @@ def generate_sql(question: str, *, model: str | None = None) -> str:
         model = model_router.ModelRouter().route(task_type="sql")
 
     template = prompt_templates.load_template(model, "sql")
-    prompt = prompt_templates.fill_template(template, question)
+    schema = database.describe_schema()
+    prompt = prompt_templates.fill_template(template, question, schema=schema)
 
     req = urlrequest.Request(
         OLLAMA_URL,

--- a/MCP_119/tests/test_database.py
+++ b/MCP_119/tests/test_database.py
@@ -7,15 +7,16 @@ import database
 
 
 class FakeCursor:
-    def __init__(self):
+    def __init__(self, rows=None):
         self.description = [("id",), ("name",)]
         self.executed = None
+        self.rows = rows or [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}]
 
     def execute(self, query):
         self.executed = query
 
     def fetchall(self):
-        return [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}]
+        return self.rows
 
     def close(self):
         pass
@@ -28,19 +29,38 @@ class FakeCursor:
 
 
 class FakeConnection:
+    def __init__(self, rows=None):
+        self.rows = rows
+
     def cursor(self, cursor_factory=None):
-        return FakeCursor()
+        return FakeCursor(self.rows)
 
     def close(self):
         pass
 
 
 class FakePsycopg:
+    def __init__(self, rows=None):
+        self.rows = rows
+
     def connect(self, *args, **kwargs):
-        return FakeConnection()
+        return FakeConnection(self.rows)
 
 
 def test_execute_query(monkeypatch):
     monkeypatch.setattr(database, "psycopg2", FakePsycopg())
     result = database.execute_query("SELECT * FROM test")
     assert result == [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}]
+
+
+def test_describe_schema(monkeypatch):
+    rows = [
+        {"table_name": "users", "column_name": "id"},
+        {"table_name": "users", "column_name": "name"},
+        {"table_name": "orders", "column_name": "id"},
+        {"table_name": "orders", "column_name": "amount"},
+    ]
+    monkeypatch.setattr(database, "psycopg2", FakePsycopg(rows))
+    schema = database.describe_schema()
+    assert "users(id, name)" in schema
+    assert "orders(id, amount)" in schema

--- a/MCP_119/tests/test_sql_generator.py
+++ b/MCP_119/tests/test_sql_generator.py
@@ -7,6 +7,7 @@ from urllib import request as urlrequest
 import json
 import sql_generator
 import pytest
+import database
 
 
 class FakeResponse:
@@ -28,6 +29,7 @@ def test_generate_sql(monkeypatch):
         return FakeResponse(json.dumps({"response": "SELECT 1;"}).encode())
 
     monkeypatch.setattr(urlrequest, "urlopen", fake_urlopen)
+    monkeypatch.setattr(database, "describe_schema", lambda: "tbl(col)")
     sql = sql_generator.generate_sql("test question")
     assert sql == "SELECT 1;"
 
@@ -37,6 +39,7 @@ def test_generate_sql_invalid(monkeypatch):
         return FakeResponse(json.dumps({"response": "列出前五筆資料"}).encode())
 
     monkeypatch.setattr(urlrequest, "urlopen", fake_urlopen)
+    monkeypatch.setattr(database, "describe_schema", lambda: "tbl(col)")
     with pytest.raises(ValueError):
         sql_generator.generate_sql("bad question")
 
@@ -51,5 +54,6 @@ def test_generate_sql_streaming(monkeypatch):
         return FakeResponse(data.encode())
 
     monkeypatch.setattr(urlrequest, "urlopen", fake_urlopen)
+    monkeypatch.setattr(database, "describe_schema", lambda: "tbl(col)")
     sql = sql_generator.generate_sql("question")
     assert sql == "SELECT 1;"


### PR DESCRIPTION
## Summary
- include DB schema description in SQL prompt templates
- allow prompt templates to accept additional placeholders
- add database.describe_schema utility
- generate SQL queries using schema-aware prompts
- update unit tests for new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686648ac94a48323bef946d265b8e254