### PR TITLE
Improve SQL generation cleaning

### DIFF
--- a/MCP_119/tests/test_sql_generator.py
+++ b/MCP_119/tests/test_sql_generator.py
@@ -57,3 +57,13 @@ def test_generate_sql_streaming(monkeypatch):
     monkeypatch.setattr(database, "describe_schema", lambda: "tbl(col)")
     sql = sql_generator.generate_sql("question")
     assert sql == "SELECT 1;"
+
+
+def test_generate_sql_codeblock(monkeypatch):
+    def fake_urlopen(req):
+        return FakeResponse(json.dumps({"response": "```sql\nSELECT 1;\n```"}).encode())
+
+    monkeypatch.setattr(urlrequest, "urlopen", fake_urlopen)
+    monkeypatch.setattr(database, "describe_schema", lambda: "tbl(col)")
+    sql = sql_generator.generate_sql("question")
+    assert sql == "SELECT 1;"


### PR DESCRIPTION
## Summary
- ensure imports in `sql_generator` are grouped
- strip markdown fences from generated SQL
- test handling of code-fenced SQL output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68664dccce008323a3a5270d7f0fc359