### PR TITLE
Add SQL summary and display

### DIFF
--- a/MCP_119/backend/main.py
+++ b/MCP_119/backend/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, WebSocket
 from pydantic import BaseModel
+from utils import summarize_results
 import json
 from fastapi.middleware.cors import CORSMiddleware
 import jsonrpc
@@ -183,4 +184,10 @@ async def execute_sql(request: SQLExecuteRequest):
         )
     if request.user_id:
         context_manager.record(request.user_id, request.query, json.dumps(results))
-    return jsonrpc.build_response(result={"results": results, "model": request.model})
+    summary = summarize_results(results)
+    return jsonrpc.build_response(result={
+        "results": results,
+        "model": request.model,
+        "sql": request.query,
+        "summary": summary,
+    })

--- a/MCP_119/backend/utils.py
+++ b/MCP_119/backend/utils.py
@@ -1,0 +1,10 @@
+"""Utility helpers for the backend."""
+
+
+def summarize_results(results: list[dict]) -> str:
+    """Return a short human friendly summary for query results."""
+    if not results:
+        return "沒有任何資料。"
+    row_count = len(results)
+    columns = ", ".join(results[0].keys())
+    return f"共 {row_count} 筆資料，欄位包含 {columns}。"

--- a/MCP_119/frontend/home/src/App.js
+++ b/MCP_119/frontend/home/src/App.js
@@ -4,6 +4,8 @@ import './App.css';
 function App() {
   const [query, setQuery] = useState('');
   const [result, setResult] = useState(null);
+  const [sql, setSql] = useState('');
+  const [summary, setSummary] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [models, setModels] = useState([]);
@@ -36,6 +38,8 @@ function App() {
     setLoading(true);
     setError(null);
     setResult(null);
+    setSql('');
+    setSummary('');
     try {
       const sqlResp = await fetch('/api/sql', {
         method: 'POST',
@@ -49,6 +53,7 @@ function App() {
       if (sqlData.error) {
         throw new Error(sqlData.error);
       }
+      setSql(sqlData.sql);
       const response = await fetch('/api/sql/execute', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -65,7 +70,9 @@ function App() {
       if (data.error) {
         setError(data.error.message || 'Server error');
       } else {
-        setResult(data.result ?? data);
+        setResult(data.result?.results || data.results || []);
+        setSummary(data.result?.summary || data.summary || '');
+        setSql(data.result?.sql || sqlData.sql);
       }
     } catch (err) {
       setError(err.message);
@@ -95,6 +102,9 @@ function App() {
       </form>
       <div className="query-result">
         {error && <p className="error">{error}</p>}
+        {sql && (
+          <pre className="generated-sql">{sql}</pre>
+        )}
         {Array.isArray(result) ? (
           <table className="result-table">
             <thead>
@@ -117,6 +127,7 @@ function App() {
         ) : (
           result && <pre>{JSON.stringify(result, null, 2)}</pre>
         )}
+        {summary && <p className="summary">{summary}</p>}
       </div>
     </div>
   );

--- a/MCP_119/tests/test_result_summary.py
+++ b/MCP_119/tests/test_result_summary.py
@@ -1,0 +1,19 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "backend")))
+
+from utils import summarize_results
+
+
+def test_summarize_results_empty():
+    assert summarize_results([]) == "沒有任何資料。"
+
+
+def test_summarize_results_basic():
+    rows = [
+        {"id": 1, "name": "Alice"},
+        {"id": 2, "name": "Bob"},
+    ]
+    summary = summarize_results(rows)
+    assert "2" in summary
+    assert "id" in summary and "name" in summary


### PR DESCRIPTION
## Summary
- provide helper to summarize SQL query results
- return executed SQL and summary in `/sql/execute`
- show generated SQL and summary in the React UI
- test the new summary helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686669b6bde48323921a12a8cb876922