### PR TITLE
Add editable SQL section in UI

### DIFF
--- a/MCP_119/frontend/home/src/App.css
+++ b/MCP_119/frontend/home/src/App.css
@@ -32,27 +32,49 @@
   transition: background-color 0.2s ease;
 }
 
+
 .query-form button:hover {
   background-color: #0069d9;
 }
 
-.query-result {
+.section {
   text-align: left;
   width: 100%;
   max-width: 800px;
-  margin: 0 auto;
+  margin-bottom: 1rem;
   background: #fff;
   padding: 1rem;
   border-radius: 6px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-.generated-sql {
-  background: #f8f9fa;
+.query-result {
+  margin: 0 auto;
+}
+
+
+.sql-editor textarea {
+  width: 100%;
+  min-height: 80px;
   padding: 0.5rem;
   border-radius: 4px;
-  margin-bottom: 1rem;
-  overflow-x: auto;
+  border: 1px solid #ccc;
+  font-family: monospace;
+  margin-bottom: 0.5rem;
+}
+
+.sql-editor button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  background-color: #28a745;
+  color: #fff;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.sql-editor button:hover {
+  background-color: #218838;
 }
 
 .error {


### PR DESCRIPTION
## Summary
- modernize UI layout by introducing `.section` container style
- allow editing generated SQL in a new SQL editor area
- execute modified SQL on demand via `Run SQL` button

## Testing
- `npm test --prefix frontend/home --silent` *(fails: react-scripts not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867244305048323b7aeffa1d53d4fc1