### PR TITLE
Include sample data in SQL prompt

### DIFF
--- a/MCP_119/backend/database.py
+++ b/MCP_119/backend/database.py
@@ -54,3 +54,17 @@ def describe_schema() -> str:
     return "; ".join(
         f"{tbl}({', '.join(cols)})" for tbl, cols in tables.items()
     )
+
+
+def get_random_rows(table: str, limit: int = 3, *, schema: str | None = None) -> list[dict]:
+    """Return ``limit`` random rows from the specified table."""
+    conn = _get_connection()
+    try:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            tbl = f"{schema}.{table}" if schema else table
+            query = f"SELECT * FROM {tbl} ORDER BY RANDOM() LIMIT {limit}"
+            cur.execute(query)
+            rows = cur.fetchall()
+            return [dict(row) for row in rows]
+    finally:
+        conn.close()

--- a/MCP_119/backend/prompt_templates.py
+++ b/MCP_119/backend/prompt_templates.py
@@ -8,6 +8,7 @@ PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
         "sql": (
             "Given the database schema:\n{schema}\n"
             "指定emergence(schema )中的 emergency_calls 為欲查詢資料庫\n"
+            "以下是隨機抽出的3筆資料供參考:\n{samples}\n"
             "Write an SQL query for: {query}\n"
             "Respond only with a valid SQL statement and filter out any non-SQL text."
         ),
@@ -17,6 +18,7 @@ PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
         "sql": (
             "Given the database schema:\n{schema}\n"
             "指定emergence(schema )中的 emergency_calls 為欲查詢資料庫\n"
+            "以下是隨機抽出的3筆資料供參考:\n{samples}\n"
             "Write an SQL query for: {query}\n"
             "Respond only with a valid SQL statement and filter out any non-SQL text."
         ),
@@ -29,6 +31,7 @@ PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
         "sql": (
             "Given the database schema:\n{schema}\n"
             "指定emergence(schema )中的 emergency_calls 為欲查詢資料庫\n"
+            "以下是隨機抽出的3筆資料供參考:\n{samples}\n"
             "Write an SQL query for: {query}\n"
             "Respond only with a valid SQL statement and filter out any non-SQL text."
         ),

--- a/MCP_119/backend/sql_generator.py
+++ b/MCP_119/backend/sql_generator.py
@@ -38,7 +38,14 @@ def generate_sql(question: str, *, model: str | None = None) -> str:
 
     template = prompt_templates.load_template(model, "sql")
     schema = database.describe_schema()
-    prompt = prompt_templates.fill_template(template, question, schema=schema)
+    samples = database.get_random_rows("emergency_calls", limit=3, schema="emergence")
+    sample_text = "\n".join(str(row) for row in samples)
+    prompt = prompt_templates.fill_template(
+        template,
+        question,
+        schema=schema,
+        samples=sample_text,
+    )
 
     req = urlrequest.Request(
         OLLAMA_URL,

--- a/MCP_119/tests/test_database.py
+++ b/MCP_119/tests/test_database.py
@@ -64,3 +64,10 @@ def test_describe_schema(monkeypatch):
     schema = database.describe_schema()
     assert "users(id, name)" in schema
     assert "orders(id, amount)" in schema
+
+
+def test_get_random_rows(monkeypatch):
+    rows = [{"id": 1}, {"id": 2}, {"id": 3}]
+    monkeypatch.setattr(database, "psycopg2", FakePsycopg(rows))
+    result = database.get_random_rows("tbl", limit=2, schema="sch")
+    assert result == rows

--- a/MCP_119/tests/test_sql_generator.py
+++ b/MCP_119/tests/test_sql_generator.py
@@ -30,6 +30,7 @@ def test_generate_sql(monkeypatch):
 
     monkeypatch.setattr(urlrequest, "urlopen", fake_urlopen)
     monkeypatch.setattr(database, "describe_schema", lambda: "tbl(col)")
+    monkeypatch.setattr(database, "get_random_rows", lambda *a, **k: [{"id": 1}])
     sql = sql_generator.generate_sql("test question")
     assert sql == "SELECT 1;"
 
@@ -40,6 +41,7 @@ def test_generate_sql_invalid(monkeypatch):
 
     monkeypatch.setattr(urlrequest, "urlopen", fake_urlopen)
     monkeypatch.setattr(database, "describe_schema", lambda: "tbl(col)")
+    monkeypatch.setattr(database, "get_random_rows", lambda *a, **k: [{"id": 1}])
     with pytest.raises(ValueError):
         sql_generator.generate_sql("bad question")
 
@@ -55,6 +57,7 @@ def test_generate_sql_streaming(monkeypatch):
 
     monkeypatch.setattr(urlrequest, "urlopen", fake_urlopen)
     monkeypatch.setattr(database, "describe_schema", lambda: "tbl(col)")
+    monkeypatch.setattr(database, "get_random_rows", lambda *a, **k: [{"id": 1}])
     sql = sql_generator.generate_sql("question")
     assert sql == "SELECT 1;"
 
@@ -65,5 +68,6 @@ def test_generate_sql_codeblock(monkeypatch):
 
     monkeypatch.setattr(urlrequest, "urlopen", fake_urlopen)
     monkeypatch.setattr(database, "describe_schema", lambda: "tbl(col)")
+    monkeypatch.setattr(database, "get_random_rows", lambda *a, **k: [{"id": 1}])
     sql = sql_generator.generate_sql("question")
     assert sql == "SELECT 1;"


### PR DESCRIPTION
## Summary
- add `get_random_rows` helper for sampling DB rows
- inject random emergency call samples into SQL prompt templates
- use the sample data when building prompts
- update database and SQL generator tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68672ddbe7a48323bf9260a92d6f36ab