### PR TITLE
Add PostGIS sample endpoint and map loader

### DIFF
--- a/MCP_119/backend/main.py
+++ b/MCP_119/backend/main.py
@@ -191,3 +191,26 @@ async def execute_sql(request: SQLExecuteRequest):
         "sql": request.query,
         "summary": summary,
     })
+
+
+@app.get("/calls")
+@app.get("/api/calls")
+async def get_emergency_calls(limit: int = 100):
+    """Return rows from the emergency_calls table with geometry as WKT."""
+    try:
+        limit = int(limit)
+    except ValueError:
+        limit = 100
+    if limit < 1:
+        limit = 1
+    if limit > 1000:
+        limit = 1000
+    query = (
+        "SELECT *, ST_AsText(geom) AS geom_wkt "
+        "FROM emergence.emergency_calls LIMIT %d" % limit
+    )
+    rows = database.execute_query(query)
+    for row in rows:
+        if "geom_wkt" in row:
+            row["geom"] = row.pop("geom_wkt")
+    return {"rows": rows}

--- a/MCP_119/frontend/home/src/App.js
+++ b/MCP_119/frontend/home/src/App.js
@@ -13,6 +13,23 @@ function App() {
   const [models, setModels] = useState([]);
   const [model, setModel] = useState('');
 
+  const loadCalls = async () => {
+    setLoading(true);
+    setError(null);
+    setSql('');
+    setSummary('');
+    try {
+      const resp = await fetch('/api/calls');
+      if (!resp.ok) throw new Error('Failed to fetch data');
+      const data = await resp.json();
+      setResult(data.rows || []);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   useEffect(() => {
     const fetchModels = async () => {
       try {
@@ -125,6 +142,14 @@ function App() {
             {loading ? <Loader /> : '查詢'}
           </button>
         </form>
+
+        <button
+          onClick={loadCalls}
+          disabled={loading}
+          className="bg-purple-500 text-white px-4 py-2 rounded hover:bg-purple-600 transition"
+        >
+          {loading ? <Loader /> : '載入示範資料'}
+        </button>
 
         {sql && (
           <div className="space-y-2">


### PR DESCRIPTION
## Summary
- extend API with `/calls` endpoint for emergency call data
- enhance frontend App with button to fetch map sample data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68673b9750a08323bb0f5155cb2a6338