### PR TITLE
Add llama3.2 model

### DIFF
--- a/MCP_119/backend/model_router.py
+++ b/MCP_119/backend/model_router.py
@@ -12,6 +12,8 @@ class ModelRouter:
             # All three models generate SQL queries
             "code": "phi3:3.8b",
             "sql": "sqlcoder:7b",
+            # llama3.2:3b is available for general NLP tasks
+            "chat": "llama3.2:3b",
         }
         # Optional user specific preferencesThe origin zombies. Engineering **** don't you just this is she's. Like a girl tomorrow. Hey, Cortana. Weather in the two months because physical dialog application is happy hold this high time. With them, wait. Deep Sega deep seeker sitting white. Viber code is that causes. Are you so? **** Defense. No, it's not. So it kind of stuff was entry people station bottled in the whole station. Was loose on me. Hey, Cortana. Go to. Date on your phone. Hey, Cortana, do you think she make a sense of that? Not sure that you're the best. Using that. Second. 
         self.user_mapping: Dict[str, str] = {}

--- a/MCP_119/backend/prompt_templates.py
+++ b/MCP_119/backend/prompt_templates.py
@@ -43,6 +43,22 @@ PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
             "Respond only with a valid SQL statement and filter out any non-SQL text."
         ),
     },
+    "llama3.2:3b": {
+        "sql": (
+            "Given the database schema:\n{schema}\n"
+            "The table to query is `emergency_calls` in the `emergence` schema.\n"
+            "Always use `FROM emergence.emergency_calls` in the SQL.\n"
+            "Table columns include: {columns}\n"
+            "You must generate the SQL based strictly on the provided columns (do not modify them) and the question.\n"
+            "Here are 3 randomly sampled records for reference:\n{samples}\n"
+            "Write an SQL query for: {query}\n"
+            "Respond only with a valid SQL statement and filter out any non-SQL text."
+        ),
+        "nlp": (
+            "Given the SQL query results:\n{results}\n"
+            "Answer the question: {query} in a friendly and helpful way."
+        ),
+    },
 }
 
 

--- a/MCP_119/tests/test_model_router_list.py
+++ b/MCP_119/tests/test_model_router_list.py
@@ -9,5 +9,5 @@ def test_list_models():
     router = ModelRouter()
     router.add_user_preference("alice", "custom-model")
     models = router.list_models()
-    assert set(models) == {"phi3:3.8b", "qwen2.5-coder:7b", "sqlcoder:7b", "custom-model"}
+    assert set(models) == {"phi3:3.8b", "qwen2.5-coder:7b", "sqlcoder:7b", "llama3.2:3b", "custom-model"}
 


### PR DESCRIPTION
## Summary
- support llama3.2:3b in router and prompt templates
- expect llama3.2:3b in model list tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867480b409c8323a1417fa5fc7ff016