### PR TITLE
Add qwen2.5-coder:3b model

### DIFF
--- a/MCP_119/backend/model_router.py
+++ b/MCP_119/backend/model_router.py
@@ -9,6 +9,8 @@ class ModelRouter:
         self.task_mapping: Dict[str, str] = {
             # qwen2.5-coder:7b handles user facing responses
             "nlp": "qwen2.5-coder:7b",
+            # qwen2.5-coder:3b is a lightweight variant for simple NLP tasks
+            "nlp-small": "qwen2.5-coder:3b",
             # All three models generate SQL queries
             "code": "phi3:3.8b",
             "sql": "sqlcoder:7b",

--- a/MCP_119/backend/prompt_templates.py
+++ b/MCP_119/backend/prompt_templates.py
@@ -31,6 +31,22 @@ PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
             "Answer the question: {query} in a friendly and helpful way."
         ),
     },
+    "qwen2.5-coder:3b": {
+        "sql": (
+            "Given the database schema:\n{schema}\n"
+            "The table to query is `emergency_calls` in the `emergence` schema.\n"
+            "Always use `FROM emergence.emergency_calls` in the SQL.\n"
+            "Table columns include: {columns}\n"
+            "You must generate the SQL based strictly on the provided columns (do not modify them) and the question.\n"
+            "Here are 3 randomly sampled records for reference:\n{samples}\n"
+            "Write an SQL query for: {query}\n"
+            "Respond only with a valid SQL statement and filter out any non-SQL text."
+        ),
+        "nlp": (
+            "Given the SQL query results:\n{results}\n"
+            "Answer the question: {query} in a friendly and helpful way."
+        ),
+    },
     "sqlcoder:7b": {
         "sql": (
             "Given the database schema:\n{schema}\n"

--- a/MCP_119/tests/test_model_router_list.py
+++ b/MCP_119/tests/test_model_router_list.py
@@ -9,5 +9,12 @@ def test_list_models():
     router = ModelRouter()
     router.add_user_preference("alice", "custom-model")
     models = router.list_models()
-    assert set(models) == {"phi3:3.8b", "qwen2.5-coder:7b", "sqlcoder:7b", "llama3.2:3b", "custom-model"}
+    assert set(models) == {
+        "phi3:3.8b",
+        "qwen2.5-coder:7b",
+        "qwen2.5-coder:3b",
+        "sqlcoder:7b",
+        "llama3.2:3b",
+        "custom-model",
+    }
 

--- a/MCP_119/tests/test_prompt_context_integration.py
+++ b/MCP_119/tests/test_prompt_context_integration.py
@@ -13,7 +13,7 @@ def test_build_prompt_with_history():
     ctx.record("alice", "how are you", "fine")
     history = ctx.get_history("alice")
     prompt = build_prompt_with_history(
-        "qwen2.5-coder:7b", "nlp", "what's up?", history, results="[]"
+        "qwen2.5-coder:3b", "nlp", "what's up?", history, results="[]"
     )
     assert "user: hi" in prompt
     assert "assistant: hello" in prompt

--- a/MCP_119/tests/test_prompt_templates.py
+++ b/MCP_119/tests/test_prompt_templates.py
@@ -7,8 +7,10 @@ from prompt_templates import load_template, fill_template
 
 
 def test_load_template():
-    template = load_template("qwen2.5-coder:7b", "nlp")
-    assert "SQL query results" in template
+    template_big = load_template("qwen2.5-coder:7b", "nlp")
+    template_small = load_template("qwen2.5-coder:3b", "nlp")
+    assert "SQL query results" in template_big
+    assert "SQL query results" in template_small
 
 
 def test_fill_template():


### PR DESCRIPTION
## Summary
- support new model `qwen2.5-coder:3b` in `ModelRouter`
- include templates for the new model
- update tests for model listing and prompt helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686749c2efc4832389e17703555f0fbe