### PR TITLE
Add llama3 result answer feature

### DIFF
--- a/MCP_119/backend/answer_generator.py
+++ b/MCP_119/backend/answer_generator.py
@@ -1,0 +1,24 @@
+import json
+import os
+from urllib import request as urlrequest
+
+import prompt_templates
+
+OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434/api/generate")
+
+
+def generate_answer(question: str, results: list[dict], *, model: str = "llama3.2:3b") -> str:
+    """Generate a friendly natural language answer using an LLM."""
+    template = prompt_templates.load_template(model, "nlp")
+    results_text = json.dumps(results, ensure_ascii=False)
+    prompt = prompt_templates.fill_template(template, question, results=results_text)
+    req = urlrequest.Request(
+        OLLAMA_URL,
+        data=json.dumps({"model": model, "prompt": prompt, "stream": False}).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urlrequest.urlopen(req) as resp:
+        text = resp.read().decode()
+    data = json.loads(text)
+    return data.get("response", "").strip()

--- a/MCP_119/frontend/home/src/App.js
+++ b/MCP_119/frontend/home/src/App.js
@@ -8,6 +8,7 @@ function App() {
   const [result, setResult] = useState(null);
   const [sql, setSql] = useState('');
   const [summary, setSummary] = useState('');
+  const [answer, setAnswer] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [models, setModels] = useState([]);
@@ -18,6 +19,7 @@ function App() {
     setError(null);
     setSql('');
     setSummary('');
+    setAnswer('');
     try {
       const resp = await fetch('/api/calls');
       if (!resp.ok) throw new Error('Failed to fetch data');
@@ -46,11 +48,11 @@ function App() {
     fetchModels();
   }, []);
 
-  const executeSql = async (querySql) => {
+  const executeSql = async (querySql, questionParam = query) => {
     const response = await fetch('/api/sql/execute', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ query: querySql, model })
+      body: JSON.stringify({ query: querySql, model, question: questionParam })
     });
     if (!response.ok) {
       const data = await response.json().catch(() => null);
@@ -65,6 +67,7 @@ function App() {
     }
     setResult(data.result?.results || data.results || []);
     setSummary(data.result?.summary || data.summary || '');
+    setAnswer(data.result?.answer || data.answer || '');
     setSql(data.result?.sql || querySql);
   };
 
@@ -79,6 +82,7 @@ function App() {
     setResult(null);
     setSql('');
     setSummary('');
+    setAnswer('');
     try {
       const sqlResp = await fetch('/api/sql', {
         method: 'POST',
@@ -89,7 +93,7 @@ function App() {
       const sqlData = await sqlResp.json();
       if (sqlData.error) throw new Error(sqlData.error);
       setSql(sqlData.sql);
-      await executeSql(sqlData.sql);
+      await executeSql(sqlData.sql, query);
     } catch (err) {
       setError(err.message);
     } finally {
@@ -103,8 +107,9 @@ function App() {
     setError(null);
     setResult(null);
     setSummary('');
+    setAnswer('');
     try {
-      await executeSql(sql);
+      await executeSql(sql, query);
     } catch (err) {
       setError(err.message);
     } finally {
@@ -201,6 +206,7 @@ function App() {
           <MapView data={result} />
         )}
 
+        {answer && <div className="text-gray-800">{answer}</div>}
         {summary && <div className="text-gray-600 italic">{summary}</div>}
       </div>
     </div>

--- a/MCP_119/tests/test_answer_generator.py
+++ b/MCP_119/tests/test_answer_generator.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "backend")))
+
+from urllib import request as urlrequest
+import json
+import answer_generator
+
+
+class FakeResponse:
+    def __init__(self, data: bytes):
+        self.data = data
+
+    def read(self):
+        return self.data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+
+def test_generate_answer(monkeypatch):
+    def fake_urlopen(req):
+        return FakeResponse(json.dumps({"response": "hello"}).encode())
+
+    monkeypatch.setattr(urlrequest, "urlopen", fake_urlopen)
+    ans = answer_generator.generate_answer("q", [{"id": 1}])
+    assert ans == "hello"


### PR DESCRIPTION
## Summary
- generate friendly answer via llama3
- include optional `question` for SQL execution
- surface the answer in the React UI
- add tests for the new answer generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867556ae140832393189766db11d3c7