### PR TITLE
Show LLM answer when available

### DIFF
--- a/MCP_119/frontend/home/src/App.js
+++ b/MCP_119/frontend/home/src/App.js
@@ -206,8 +206,11 @@ function App() {
           <MapView data={result} />
         )}
 
-        {answer && <div className="text-gray-800">{answer}</div>}
-        {summary && <div className="text-gray-600 italic">{summary}</div>}
+        {answer ? (
+          <div className="text-gray-800">{answer}</div>
+        ) : (
+          summary && <div className="text-gray-600 italic">{summary}</div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- prioritize displaying the human-like answer from llama3.2:3b
- only fall back to the summary when the answer is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686757ae1c2083239dbec9d4602bd6db