### PR TITLE
Add clickable history playback

### DIFF
--- a/MCP_119/frontend/home/src/App.js
+++ b/MCP_119/frontend/home/src/App.js
@@ -26,10 +26,10 @@ function App() {
     localStorage.setItem('history', JSON.stringify(history));
   }, [history]);
 
-  const addHistory = (question, summaryText, answerText) => {
+  const addHistory = (question, summaryText, answerText, sqlText, resultData, modelName) => {
     setHistory((prev) => [
       ...prev,
-      { question, summary: summaryText, answer: answerText },
+      { question, summary: summaryText, answer: answerText, sql: sqlText, result: resultData, model: modelName },
     ]);
   };
 
@@ -89,13 +89,17 @@ function App() {
     if (data.error) {
       throw new Error(data.error.message || 'Server error');
     }
-    setResult(data.result?.results || data.results || []);
-    setSummary(data.result?.summary || data.summary || '');
-    setAnswer(data.result?.answer || data.answer || '');
-    setSql(data.result?.sql || querySql);
+    const results = data.result?.results || data.results || [];
     const summaryText = data.result?.summary || data.summary || '';
     const answerText = data.result?.answer || data.answer || '';
-    addHistory(questionParam, summaryText, answerText);
+    const sqlText = data.result?.sql || querySql;
+
+    setResult(results);
+    setSummary(summaryText);
+    setAnswer(answerText);
+    setSql(sqlText);
+
+    addHistory(questionParam, summaryText, answerText, sqlText, results, model);
   };
 
   const handleSubmit = async (e) => {
@@ -141,6 +145,17 @@ function App() {
       setError(err.message);
     } finally {
       setLoading(false);
+    }
+  };
+
+  const openHistory = (item) => {
+    setQuery(item.question || '');
+    setSql(item.sql || '');
+    setResult(item.result || null);
+    setSummary(item.summary || '');
+    setAnswer(item.answer || '');
+    if (item.model) {
+      setModel(item.model);
     }
   };
 
@@ -241,7 +256,7 @@ function App() {
         )}
 
         </div>
-        <HistorySidebar history={history} clearHistory={clearHistory} />
+        <HistorySidebar history={history} clearHistory={clearHistory} openHistory={openHistory} />
       </div>
     </div>
   );

--- a/MCP_119/frontend/home/src/HistorySidebar.js
+++ b/MCP_119/frontend/home/src/HistorySidebar.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-function HistorySidebar({ history, clearHistory }) {
+function HistorySidebar({ history, clearHistory, openHistory }) {
   if (!history || history.length === 0) return null;
   return (
     <div className="w-64 bg-white shadow-md rounded-lg p-4 space-y-2 md:ml-4 h-fit">
@@ -15,7 +15,7 @@ function HistorySidebar({ history, clearHistory }) {
       </div>
       <ul className="list-disc pl-5 space-y-2">
         {history.map((item, idx) => (
-          <li key={idx}>
+          <li key={idx} className="cursor-pointer" onClick={() => openHistory(item)}>
             <div className="font-semibold">{item.question}</div>
             {item.answer ? (
               <div>{item.answer}</div>


### PR DESCRIPTION
## Summary
- store SQL, results and model in history
- allow clicking history items to restore previous query

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686aa6e3d86c83239c3705e58bbf382d