### PR TITLE
Improve chart query

### DIFF
--- a/MCP_119/README.md
+++ b/MCP_119/README.md
@@ -31,6 +31,12 @@ Before running the stack for the first time, build the React application so Ngin
 ```
 
 The frontend also visualizes query results using a simple bar chart when numeric data is available.
+When preparing the chart, the UI sends a second query by appending
+"加入更多相同欄位的資料" to the user's original question.
+This instructs the LLM to return more rows with the same columns so the
+chart can show data from additional records (for example other fire
+stations) while the main answer and table remain based on the original
+question.
 
 Stop the stack:
 

--- a/MCP_119/frontend/home/src/App.js
+++ b/MCP_119/frontend/home/src/App.js
@@ -5,6 +5,12 @@ import MapView from './MapView';
 import HistorySidebar from './HistorySidebar';
 import ResultChart from './ResultChart';
 
+// Suffix appended to the user's question when requesting
+// additional data for chart rendering. This prompts the LLM
+// to return more rows with the same fields so the chart can
+// visualise data such as other fire stations in the example.
+const CHART_QUERY_SUFFIX = '加入更多相同欄位的資料';
+
 function App() {
   const [query, setQuery] = useState('');
   const [result, setResult] = useState(null);
@@ -60,7 +66,7 @@ function App() {
   }, []);
 
   const fetchChartData = async (questionParam) => {
-    const chartQuestion = `${questionParam}，加入更多相同欄位的資料`;
+    const chartQuestion = `${questionParam}，${CHART_QUERY_SUFFIX}`;
     try {
       const sqlResp = await fetch('/api/sql', {
         method: 'POST',


### PR DESCRIPTION
## Summary
- add `CHART_QUERY_SUFFIX` constant
- use the constant when generating chart queries
- document the new chart query behaviour in README

## Testing
- `pytest MCP_119/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_686c97f21ebc83239a6a154d93681061