### PR TITLE
Add chart SQL display

### DIFF
--- a/MCP_119/README.md
+++ b/MCP_119/README.md
@@ -37,6 +37,8 @@ This instructs the LLM to return more rows with the same columns so the
 chart can show data from additional records (for example other fire
 stations) while the main answer and table remain based on the original
 question.
+The additional SQL used to fetch data for the chart is now shown below the
+main query results so you can inspect or reuse it if needed.
 
 Stop the stack:
 


### PR DESCRIPTION
## Summary
- update README instructions on chart data
- show generated SQL for the chart in UI
- keep chart SQL in history

## Testing
- `pytest -q`
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ca5225fc0832391665d76e4afdd5c