### PR TITLE
Implement helper to generate chart SQL

### DIFF
--- a/MCP_119/README.md
+++ b/MCP_119/README.md
@@ -39,6 +39,8 @@ stations) while the main answer and table remain based on the original
 question.
 The additional SQL used to fetch data for the chart is now shown below the
 main query results so you can inspect or reuse it if needed.
+You can also generate this follow-up query directly using the
+`generate_chart_sql()` helper in `backend/sql_generator.py`.
 
 Stop the stack:
 

--- a/MCP_119/backend/sql_generator.py
+++ b/MCP_119/backend/sql_generator.py
@@ -10,6 +10,10 @@ import prompt_templates
 
 OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434/api/generate")
 
+# When generating chart data the UI appends this suffix to the user's
+# original question to request additional rows with the same columns.
+CHART_QUERY_SUFFIX = "加入更多相同欄位的資料"
+
 
 SQL_START = re.compile(r"^(SELECT|INSERT|UPDATE|DELETE|CREATE|DROP|WITH)\b", re.IGNORECASE)
 
@@ -86,3 +90,9 @@ def generate_sql(question: str, *, model: str | None = None) -> str:
     if not _is_valid_sql(sql):
         raise ValueError(f"Generated text is not valid SQL: {sql}")
     return sql
+
+
+def generate_chart_sql(question: str, *, model: str | None = None) -> str:
+    """Generate SQL for chart data based on the user's question."""
+    chart_question = f"{question}，{CHART_QUERY_SUFFIX}"
+    return generate_sql(chart_question, model=model)

--- a/MCP_119/tests/test_sql_generator.py
+++ b/MCP_119/tests/test_sql_generator.py
@@ -72,6 +72,16 @@ def test_generate_sql_codeblock(monkeypatch):
     monkeypatch.setattr(urlrequest, "urlopen", fake_urlopen)
     monkeypatch.setattr(database, "describe_schema", lambda: "tbl(col)")
     monkeypatch.setattr(database, "get_random_rows", lambda *a, **k: [{"id": 1}])
-    monkeypatch.setattr(database, "get_table_columns", lambda *a, **k: ["id"]) 
+    monkeypatch.setattr(database, "get_table_columns", lambda *a, **k: ["id"])
     sql = sql_generator.generate_sql("question")
+    assert sql == "SELECT 1;"
+
+
+def test_generate_chart_sql(monkeypatch):
+    def fake_generate_sql(question: str, *, model: str | None = None):
+        assert question == "q，" + sql_generator.CHART_QUERY_SUFFIX
+        return "SELECT 1;"
+
+    monkeypatch.setattr(sql_generator, "generate_sql", fake_generate_sql)
+    sql = sql_generator.generate_chart_sql("q", model="m")
     assert sql == "SELECT 1;"


### PR DESCRIPTION
## Summary
- support generating chart SQL using `generate_chart_sql`
- document chart SQL helper in README
- add unit test for new function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cb271b77c83239d36acc5cbfb18b3