### PR TITLE
Fix chart SQL missing in React app

### DIFF
--- a/MCP_119/frontend/home/src/App.js
+++ b/MCP_119/frontend/home/src/App.js
@@ -84,6 +84,7 @@ function App() {
 
       const results = execData.result?.results || execData.results || [];
       setChartResult(results);
+      setChartSql(sqlData.sql);
       return { chartResults: results, chartSql: sqlData.sql };
     } catch (_) {
       setChartResult(null);


### PR DESCRIPTION
## Summary
- ensure follow-up chart query SQL is stored in state

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd41652a0832383d5916fbc776837