### PR TITLE
Fix model list display in React frontend

### DIFF
--- a/MCP_119/frontend/home/src/App.js
+++ b/MCP_119/frontend/home/src/App.js
@@ -51,7 +51,11 @@ function App() {
         const resp = await fetch('/api/models');
         if (resp.ok) {
           const data = await resp.json();
-          const ms = Array.isArray(data.models) ? data.models : [];
+          const ms = Array.isArray(data.models)
+            ? data.models
+            : Array.isArray(data.result?.models)
+            ? data.result.models
+            : [];
           setModels(ms);
           if (ms.length > 0) {
             setModel(ms[0]);


### PR DESCRIPTION
## Summary
- correctly parse JSON-RPC response for model list

## Testing
- `pytest -q`
- `CI=true npm test --prefix frontend/home --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d42ad77b88323b05f3fc54f989f09