### PR TITLE
Configure ollama to use GPU

### DIFF
--- a/MCP_119/README.md
+++ b/MCP_119/README.md
@@ -19,6 +19,14 @@ Docker Compose, the `OLLAMA_URL` environment variable is set so the backend
 calls the `ollama` container instead. The backend disables streaming when
 requesting a response from Ollama so a complete JSON payload is returned.
 
+The `ollama` service is configured to run with GPU acceleration. It sets
+`NVIDIA_VISIBLE_DEVICES=all` and requires the NVIDIA container runtime. You
+can verify GPU access with:
+
+```bash
+docker compose exec ollama nvidia-smi
+```
+
 Start the stack:
 
 ```bash

--- a/MCP_119/docker-compose.yaml
+++ b/MCP_119/docker-compose.yaml
@@ -31,6 +31,8 @@ services:
       - "11434:11434"
     volumes:
       - ./valumes/ollama_data:/root/.ollama
+    environment:
+      NVIDIA_VISIBLE_DEVICES: all
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
## Summary
- configure `ollama` service to request GPU using `NVIDIA_VISIBLE_DEVICES`
- document how to verify GPU access for the service

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686dca599f3483238db4e1c93caf6081