### PR TITLE
Add LLM chart query endpoint

### DIFF
--- a/MCP_119/backend/prompt_templates.py
+++ b/MCP_119/backend/prompt_templates.py
@@ -14,6 +14,15 @@ PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
             "Write an SQL query for the following natural language question: {query}\n"
             "Respond only with a valid SQL statement. Do not include any explanations or extra text."
         ),
+        "chart": (
+            "Given the database schema:\n{schema}\n"
+            "The table to query is `emergency_calls` in the `emergence` schema.\n"
+            "Always use `FROM emergence.emergency_calls` in the SQL.\n"
+            "Table columns include: {columns} (you must use these column names exactly as provided, including spacing and capitalization).\n"
+            "Here are 3 randomly sampled records for reference:\n{samples}\n"
+            "Write an SQL query that lists multiple related data points for comparison in a chart based on the question: {query}\n"
+            "Respond only with a valid SQL statement. Do not include any explanations or extra text."
+        ),
     },
     "qwen2.5-coder:7b": {
         "sql": (
@@ -24,6 +33,15 @@ PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
             "Here are 3 randomly sampled records for reference:\n{samples}\n"
             "When generating the SQL, you may incorporate additional columns and inferred conditions that could provide meaningful context, even if these details are not explicitly mentioned by the user.\n"
             "Write an SQL query for the following natural language question: {query}\n"
+            "Respond only with a valid SQL statement. Do not include any explanations or extra text."
+        ),
+        "chart": (
+            "Given the database schema:\n{schema}\n"
+            "The table to query is `emergency_calls` in the `emergence` schema.\n"
+            "Always use `FROM emergence.emergency_calls` in the SQL.\n"
+            "Table columns include: {columns} (you must use these column names exactly as provided, including spacing and capitalization).\n"
+            "Here are 3 randomly sampled records for reference:\n{samples}\n"
+            "Write an SQL query that lists multiple related data points for comparison in a chart based on the question: {query}\n"
             "Respond only with a valid SQL statement. Do not include any explanations or extra text."
         ),
         "nlp": (
@@ -42,6 +60,15 @@ PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
             "Write an SQL query for the following natural language question: {query}\n"
             "Respond only with a valid SQL statement. Do not include any explanations or extra text."
         ),
+        "chart": (
+            "Given the database schema:\n{schema}\n"
+            "The table to query is `emergency_calls` in the `emergence` schema.\n"
+            "Always use `FROM emergence.emergency_calls` in the SQL.\n"
+            "Table columns include: {columns} (you must use these column names exactly as provided, including spacing and capitalization).\n"
+            "Here are 3 randomly sampled records for reference:\n{samples}\n"
+            "Write an SQL query that lists multiple related data points for comparison in a chart based on the question: {query}\n"
+            "Respond only with a valid SQL statement. Do not include any explanations or extra text."
+        ),
         "nlp": (
             "Given the SQL query results:\n{results}\n"
             "Answer the question: {query} in a friendly and helpful way. Interpret the meaning of the results yourself and do not state that the meaning is unclear."
@@ -58,6 +85,15 @@ PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
             "Write an SQL query for the following natural language question: {query}\n"
             "Respond only with a valid SQL statement. Do not include any explanations or extra text."
         ),
+        "chart": (
+            "Given the database schema:\n{schema}\n"
+            "The table to query is `emergency_calls` in the `emergence` schema.\n"
+            "Always use `FROM emergence.emergency_calls` in the SQL.\n"
+            "Table columns include: {columns} (you must use these column names exactly as provided, including spacing and capitalization).\n"
+            "Here are 3 randomly sampled records for reference:\n{samples}\n"
+            "Write an SQL query that lists multiple related data points for comparison in a chart based on the question: {query}\n"
+            "Respond only with a valid SQL statement. Do not include any explanations or extra text."
+        ),
     },
     "llama3.2:3b": {
         "sql": (
@@ -68,6 +104,15 @@ PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
             "Here are 3 randomly sampled records for reference:\n{samples}\n"
             "When generating the SQL, you may incorporate additional columns and inferred conditions that could provide meaningful context, even if these details are not explicitly mentioned by the user.\n"
             "Write an SQL query for the following natural language question: {query}\n"
+            "Respond only with a valid SQL statement. Do not include any explanations or extra text."
+        ),
+        "chart": (
+            "Given the database schema:\n{schema}\n"
+            "The table to query is `emergency_calls` in the `emergence` schema.\n"
+            "Always use `FROM emergence.emergency_calls` in the SQL.\n"
+            "Table columns include: {columns} (you must use these column names exactly as provided, including spacing and capitalization).\n"
+            "Here are 3 randomly sampled records for reference:\n{samples}\n"
+            "Write an SQL query that lists multiple related data points for comparison in a chart based on the question: {query}\n"
             "Respond only with a valid SQL statement. Do not include any explanations or extra text."
         ),
         "nlp": (

--- a/MCP_119/frontend/home/src/App.js
+++ b/MCP_119/frontend/home/src/App.js
@@ -109,17 +109,23 @@ function App() {
     setAnswer('');
     setGeojson(null);
     try {
-      const sqlResp = await fetch('/api/sql', {
+      const resp = await fetch('/api/chart', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ question: query, model })
       });
-      if (!sqlResp.ok) throw new Error('Failed to generate SQL');
-      const sqlData = await sqlResp.json();
-      if (sqlData.error) throw new Error(sqlData.error);
-      const generatedSql = sqlData.result?.sql || sqlData.sql || '';
+      if (!resp.ok) throw new Error('Failed to generate chart data');
+      const data = await resp.json();
+      if (data.error) throw new Error(data.error.message || 'Server error');
+      const generatedSql = data.result?.sql || data.sql || '';
+      const results = data.result?.results || data.results || [];
+      const summaryText = data.result?.summary || data.summary || '';
       setSql(generatedSql);
-      await executeSql(generatedSql, query);
+      setResult(results);
+      setSummary(summaryText);
+      setAnswer('');
+      setGeojson(null);
+      addHistory(query, summaryText, '', generatedSql, results, model);
     } catch (err) {
       setError(err.message);
     } finally {


### PR DESCRIPTION
## Summary
- support chart dataset prompts for each model
- generate chart SQL via new helper
- expose `/api/chart` endpoint
- fetch chart data from the frontend

## Testing
- `python -m py_compile backend/main.py backend/prompt_templates.py backend/sql_generator.py`
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e5ee8bbd883239139b37ba2e69ec2