### PR TITLE
Improve fallback answer generation

### DIFF
--- a/MCP_119/backend/main.py
+++ b/MCP_119/backend/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, WebSocket
 from pydantic import BaseModel
-from utils import summarize_results, results_to_geojson
+from utils import summarize_results, results_to_geojson, build_fallback_answer
 import json
 from fastapi.middleware.cors import CORSMiddleware
 import jsonrpc
@@ -204,7 +204,7 @@ async def execute_sql(request: SQLExecuteRequest):
         context_manager.record(request.user_id, request.query, json.dumps(results))
     summary = summarize_results(results)
     geojson = results_to_geojson(results)
-    answer = None
+    answer = ""
     if request.question:
         try:
             answer = answer_generator.generate_answer(
@@ -212,6 +212,8 @@ async def execute_sql(request: SQLExecuteRequest):
             )
         except Exception:  # pragma: no cover - depends on environment
             answer = ""
+    if not answer:
+        answer = build_fallback_answer(request.question or request.query, results)
     return jsonrpc.build_response(result={
         "results": results,
         "model": request.model,
@@ -258,6 +260,8 @@ async def ask(request: AskRequest):
         )
     except Exception:  # pragma: no cover - depends on environment
         answer = ""
+    if not answer:
+        answer = build_fallback_answer(request.question, results)
 
     return jsonrpc.build_response(result={
         "results": results,

--- a/MCP_119/backend/utils.py
+++ b/MCP_119/backend/utils.py
@@ -12,6 +12,15 @@ def summarize_results(results: list[dict]) -> str:
     return f"共 {row_count} 筆資料，欄位包含 {columns}。"
 
 
+def build_fallback_answer(question: str, results: list[dict]) -> str:
+    """Return a friendly answer using basic info when LLM output is empty."""
+    if not results:
+        return f"抱歉，沒有找到與「{question}」相關的資料。"
+    row_count = len(results)
+    columns = ", ".join(results[0].keys())
+    return f"根據「{question}」，共找到 {row_count} 筆資料，包含 {columns} 等欄位。"
+
+
 def results_to_geojson(rows: list[dict]) -> dict | None:
     """Convert query results to a GeoJSON FeatureCollection if possible."""
     features = []


### PR DESCRIPTION
## Summary
- return a friendly fallback answer when the LLM does not respond

## Testing
- `python -m py_compile backend/main.py backend/utils.py`


------
https://chatgpt.com/codex/tasks/task_e_686e9433e3a4832396ace4bf44b55cf2