### PR TITLE
Simplify result summary

### DIFF
--- a/MCP_119/backend/utils.py
+++ b/MCP_119/backend/utils.py
@@ -7,18 +7,16 @@ def summarize_results(results: list[dict]) -> str:
     """Return a short human friendly summary for query results."""
     if not results:
         return "沒有任何資料。"
-    row_count = len(results)
     columns = ", ".join(results[0].keys())
-    return f"共 {row_count} 筆資料，欄位包含 {columns}。"
+    return f"欄位包含 {columns}。"
 
 
 def build_fallback_answer(question: str, results: list[dict]) -> str:
     """Return a friendly answer using basic info when LLM output is empty."""
     if not results:
         return f"抱歉，沒有找到與「{question}」相關的資料。"
-    row_count = len(results)
     columns = ", ".join(results[0].keys())
-    return f"根據「{question}」，共找到 {row_count} 筆資料，包含 {columns} 等欄位。"
+    return f"以下是「{question}」的查詢結果，包含 {columns} 等欄位。"
 
 
 def results_to_geojson(rows: list[dict]) -> dict | None:

--- a/MCP_119/frontend/home/src/HistorySidebar.js
+++ b/MCP_119/frontend/home/src/HistorySidebar.js
@@ -21,8 +21,6 @@ function HistorySidebar({ history, clearHistory, openHistory }) {
               <div>{item.answer}</div>
             ) : item.summary ? (
               <div className="text-gray-600 italic">{item.summary}</div>
-            ) : Array.isArray(item.result) ? (
-              <div className="text-gray-600 italic">共 {item.result.length} 筆資料</div>
             ) : null}
           </li>
         ))}


### PR DESCRIPTION
## Summary
- remove row count from backend summary helpers
- drop row count hint in history sidebar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686ea0b17844832390758eecca574334