### PR TITLE
Fix answer display

### DIFF
--- a/MCP_119/backend/main.py
+++ b/MCP_119/backend/main.py
@@ -301,10 +301,25 @@ async def chart(request: ChartRequest):
 
     summary = summarize_results(results)
 
+    geojson = results_to_geojson(results)
+    answer = ""
+    try:
+        answer = answer_generator.generate_answer(
+            request.question,
+            results,
+            model=request.model or "llama3.2:3b",
+        )
+    except Exception:  # pragma: no cover - depends on environment
+        answer = ""
+    if not answer:
+        answer = build_fallback_answer(request.question, results)
+
     return jsonrpc.build_response(result={
         "results": results,
         "model": request.model,
         "sql": chart_sql,
         "base_sql": base_sql,
         "summary": summary,
+        "answer": answer,
+        "geojson": geojson,
     })

--- a/MCP_119/frontend/home/src/App.js
+++ b/MCP_119/frontend/home/src/App.js
@@ -120,12 +120,16 @@ function App() {
       const generatedSql = data.result?.sql || data.sql || '';
       const results = data.result?.results || data.results || [];
       const summaryText = data.result?.summary || data.summary || '';
+      const answerText = data.result?.answer || data.answer || '';
+      const geo = data.result?.geojson || data.geojson || null;
+
       setSql(generatedSql);
       setResult(results);
       setSummary(summaryText);
-      setAnswer('');
-      setGeojson(null);
-      addHistory(query, summaryText, '', generatedSql, results, model);
+      setAnswer(answerText);
+      setGeojson(geo);
+
+      addHistory(query, summaryText, answerText, generatedSql, results, model);
     } catch (err) {
       setError(err.message);
     } finally {


### PR DESCRIPTION
## Summary
- generate a friendly answer in the chart endpoint and return it along with GeoJSON
- show the returned answer in the React app when submitting a query

## Testing
- `npm test --prefix frontend/home` *(fails: Missing script)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f200268dc83238c9afbc1db7a0f10