### PR TITLE
Remove fallback responses

### DIFF
--- a/MCP_119/backend/main.py
+++ b/MCP_119/backend/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, WebSocket
 from pydantic import BaseModel
-from utils import summarize_results, results_to_geojson, build_fallback_answer
+from utils import summarize_results, results_to_geojson
 import json
 from fastapi.middleware.cors import CORSMiddleware
 import jsonrpc
@@ -212,8 +212,6 @@ async def execute_sql(request: SQLExecuteRequest):
             )
         except Exception:  # pragma: no cover - depends on environment
             answer = ""
-    if not answer:
-        answer = build_fallback_answer(request.question or request.query, results)
     return jsonrpc.build_response(result={
         "results": results,
         "model": request.model,
@@ -260,8 +258,6 @@ async def ask(request: AskRequest):
         )
     except Exception:  # pragma: no cover - depends on environment
         answer = ""
-    if not answer:
-        answer = build_fallback_answer(request.question, results)
 
     return jsonrpc.build_response(result={
         "results": results,
@@ -311,8 +307,6 @@ async def chart(request: ChartRequest):
         )
     except Exception:  # pragma: no cover - depends on environment
         answer = ""
-    if not answer:
-        answer = build_fallback_answer(request.question, results)
 
     return jsonrpc.build_response(result={
         "results": results,


### PR DESCRIPTION
## Summary
- rely solely on LLM answer generation instead of returning template responses

## Testing
- `python -m py_compile MCP_119/backend/*.py`
- `npm test --silent` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_686f5bfe72808323a676a79358f77bbc