### PR TITLE
Disable friendly summary messages

### DIFF
--- a/MCP_119/backend/utils.py
+++ b/MCP_119/backend/utils.py
@@ -4,19 +4,22 @@ import json
 
 
 def summarize_results(results: list[dict]) -> str:
-    """Return a short human friendly summary for query results."""
+    """Return a short summary for query results or an empty string."""
+    # Some deployments prefer not to expose human friendly messages.
+    # When this behaviour is desired simply return an empty string.
     if not results:
-        return "沒有任何資料。"
+        return ""
     columns = ", ".join(results[0].keys())
-    return f"欄位包含 {columns}。"
+    return columns
 
 
 def build_fallback_answer(question: str, results: list[dict]) -> str:
-    """Return a friendly answer using basic info when LLM output is empty."""
+    """Return a basic fallback answer or an empty string."""
+    # These responses can be suppressed by returning an empty string.
     if not results:
-        return f"抱歉，沒有找到與「{question}」相關的資料。"
+        return ""
     columns = ", ".join(results[0].keys())
-    return f"以下是「{question}」的查詢結果，包含 {columns} 等欄位。"
+    return columns
 
 
 def results_to_geojson(rows: list[dict]) -> dict | None:


### PR DESCRIPTION
## Summary
- prefer empty summaries and fallback answers in utils

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f894262608323878e24a32c65cfd7