### PR TITLE
Update NLP prompts to finish answers with a question

### DIFF
--- a/MCP_119/backend/prompt_templates.py
+++ b/MCP_119/backend/prompt_templates.py
@@ -46,7 +46,8 @@ PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
         ),
         "nlp": (
             "Given the SQL query results:\n{results}\n"
-            "Answer the question: {query} in a friendly and helpful way. Interpret the meaning of the results yourself and do not state that the meaning is unclear."
+            "Answer the question: {query} in a friendly and helpful way. Interpret the meaning of the results yourself and do not state that the meaning is unclear. "
+            "Finish your answer with a short follow-up question to keep the conversation going."
         ),
     },
     "qwen2.5-coder:3b": {
@@ -71,7 +72,8 @@ PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
         ),
         "nlp": (
             "Given the SQL query results:\n{results}\n"
-            "Answer the question: {query} in a friendly and helpful way. Interpret the meaning of the results yourself and do not state that the meaning is unclear."
+            "Answer the question: {query} in a friendly and helpful way. Interpret the meaning of the results yourself and do not state that the meaning is unclear. "
+            "Finish your answer with a short follow-up question to keep the conversation going."
         ),
     },
     "sqlcoder:7b": {
@@ -117,7 +119,8 @@ PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
         ),
         "nlp": (
             "Given the SQL query results:\n{results}\n"
-            "Answer the question: {query} in a friendly and helpful way. Interpret the meaning of the results yourself and do not state that the meaning is unclear."
+            "Answer the question: {query} in a friendly and helpful way. Interpret the meaning of the results yourself and do not state that the meaning is unclear. "
+            "Finish your answer with a short follow-up question to keep the conversation going."
         ),
     },
 }


### PR DESCRIPTION
## Summary
- enhance NLP prompt templates
- instruct the LLM to follow up with a question after summarising query results

## Testing
- `pytest`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870b92633fc8323bf44b579eac77519