### PR TITLE
Separate chart mode from general SQL query

### DIFF
--- a/MCP_119/README.md
+++ b/MCP_119/README.md
@@ -42,8 +42,10 @@ Before running the stack for the first time, build the React application so Ngin
 (cd frontend/home && npm install && npm run build)
 
 The frontend now includes a simple chart view powered by `chart.js` and
-`react-chartjs-2`. Query results will be visualised as a bar chart when
-possible.
+`react-chartjs-2`. A checkbox lets you choose whether to generate a chart.
+When unchecked, the UI only generates SQL from your question without
+executing it. Enable the checkbox if you want chart data returned and
+visualised as a bar chart when possible.
 ```
 
 


### PR DESCRIPTION
## Summary
- allow toggling chart generation in UI
- call `/api/sql` when chart mode is off so only SQL is produced
- update README with instructions about the new checkbox

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871bf83140c832389de4fdaeb43e1cf