### PR TITLE
Fix fallback message showing during startup

### DIFF
--- a/MCP_119/frontend/home/src/App.js
+++ b/MCP_119/frontend/home/src/App.js
@@ -291,7 +291,11 @@ function App() {
             <MapView data={result || []} geojson={geojson} />
           ) : null}
 
-          <FinalResponse answer={answer} summary={summary} />
+          <FinalResponse
+            answer={answer}
+            summary={summary}
+            showFallback={Array.isArray(result) && result.length === 0}
+          />
         </div>
 
         <HistorySidebar history={history} clearHistory={clearHistory} openHistory={openHistory} />

--- a/MCP_119/frontend/home/src/FinalResponse.js
+++ b/MCP_119/frontend/home/src/FinalResponse.js
@@ -1,17 +1,17 @@
 import React from 'react';
 
-function FinalResponse({ answer, summary }) {
+function FinalResponse({ answer, summary, showFallback }) {
   if (answer) {
     return <div className="text-gray-800 whitespace-pre-wrap">{answer}</div>;
   }
   if (summary) {
     return <div className="text-gray-600 italic">{summary}</div>;
   }
-  return (
+  return showFallback ? (
     <div className="text-gray-500 italic">
       目前無法提供自然語言回覆，請參考上方查詢結果。
     </div>
-  );
+  ) : null;
 }
 
 export default FinalResponse;


### PR DESCRIPTION
## Summary
- show the fallback natural language message only when the query has no results

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874be6563948323858137c1b7f523df