### PR TITLE
Enable LLM SQL feature

### DIFF
--- a/MCP_119/README.md
+++ b/MCP_119/README.md
@@ -19,6 +19,10 @@ Docker Compose, the `OLLAMA_URL` environment variable is set so the backend
 calls the `ollama` container instead. The backend disables streaming when
 requesting a response from Ollama so a complete JSON payload is returned.
 
+Set `ENABLE_LLM_SQL=true` in the backend environment (enabled by default) to
+allow the API to call the language model for SQL generation. Set it to `false`
+if you want to disable this feature.
+
 Query summaries and fallback answers are produced using the same LLM to
 provide human-friendly explanations when possible.
 

--- a/MCP_119/backend/sql_generator.py
+++ b/MCP_119/backend/sql_generator.py
@@ -11,6 +11,12 @@ import prompt_templates
 OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434/api/generate")
 
 
+def _llm_enabled() -> bool:
+    """Return True if SQL generation via LLM is enabled."""
+    flag = os.getenv("ENABLE_LLM_SQL", "true").lower()
+    return flag not in {"0", "false", "no"}
+
+
 
 SQL_START = re.compile(r"^(SELECT|INSERT|UPDATE|DELETE|CREATE|DROP|WITH)\b", re.IGNORECASE)
 
@@ -39,6 +45,8 @@ def generate_sql(
     history: list | None = None,
 ) -> str:
     """Generate an SQL query from a natural language question using an LLM."""
+    if not _llm_enabled():
+        raise RuntimeError("LLM SQL generation is disabled")
     if model is None:
         model = model_router.ModelRouter().route(task_type="sql")
 
@@ -100,6 +108,8 @@ def generate_chart_sql(
     history: list | None = None,
 ) -> str:
     """Generate an SQL query for chart comparison using an LLM."""
+    if not _llm_enabled():
+        raise RuntimeError("LLM SQL generation is disabled")
     if model is None:
         model = model_router.ModelRouter().route(task_type="sql")
 

--- a/MCP_119/docker-compose.yaml
+++ b/MCP_119/docker-compose.yaml
@@ -50,6 +50,7 @@ services:
       DB_USER: user
       DB_PASSWORD: 123456
       OLLAMA_URL: http://ollama:11434/api/generate
+      ENABLE_LLM_SQL: "true"
     networks:
       - mcp911-network
     ports:


### PR DESCRIPTION
## Summary
- allow toggling SQL generation via `ENABLE_LLM_SQL` env var
- include the flag in docker-compose
- document the new option in README

## Testing
- `python -m py_compile MCP_119/backend/sql_generator.py`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687518354aa88323a82aa535cb48a75c