### PR TITLE
Update prompt templates to reply in Traditional Chinese

### DIFF
--- a/MCP_119/backend/prompt_templates.py
+++ b/MCP_119/backend/prompt_templates.py
@@ -28,7 +28,7 @@ PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
         "chart": CHART_TEMPLATE,
         "nlp": (
             "Given the SQL query results:\n{results}\n"
-            "Answer the question: {query} in a friendly and helpful way. Interpret the meaning of the results yourself and do not state that the meaning is unclear."
+            "請以友善且樂於助人的方式回答問題：{query}。請自行解讀結果的意義，勿表示意義不明。"
         ),
     },
     "qwen2.5-coder:3b": {
@@ -36,7 +36,7 @@ PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
         "chart": CHART_TEMPLATE,
         "nlp": (
             "Given the SQL query results:\n{results}\n"
-            "Answer the question: {query} in a friendly and helpful way. Interpret the meaning of the results yourself and do not state that the meaning is unclear."
+            "請以友善且樂於助人的方式回答問題：{query}。請自行解讀結果的意義，勿表示意義不明。"
         ),
     },
     "sqlcoder:7b": {"sql": SQL_TEMPLATE, "chart": CHART_TEMPLATE},
@@ -45,7 +45,7 @@ PROMPT_TEMPLATES: Dict[str, Dict[str, str]] = {
         "chart": CHART_TEMPLATE,
         "nlp": (
             "Given the SQL query results:\n{results}\n"
-            "Answer the question: {query} in a friendly and helpful way. Interpret the meaning of the results yourself and do not state that the meaning is unclear."
+            "請以友善且樂於助人的方式回答問題：{query}。請自行解讀結果的意義，勿表示意義不明。"
         ),
     },
 }


### PR DESCRIPTION
## Summary
- localize human-like response prompts for Chinese models to Traditional Chinese

## Testing
- `grep -n "請以友善" -n MCP_119/backend/prompt_templates.py`

------
https://chatgpt.com/codex/tasks/task_e_687726aaf94483238c18aa3cde1e16f1