### PR TITLE
Use first query results for answers

### DIFF
--- a/MCP_119/backend/context_manager.py
+++ b/MCP_119/backend/context_manager.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from textwrap import shorten
 from typing import List
 import sqlite3
+import json
 
 
 @dataclass
@@ -59,6 +60,20 @@ class ConversationContext:
             Message(row["role"], row["content"], datetime.fromisoformat(row["timestamp"]))
             for row in rows
         ]
+
+    def get_first_results(self, user_id: str) -> list | None:
+        """Return the results from the first assistant message for a user."""
+        cur = self._conn.execute(
+            "SELECT content FROM messages WHERE user_id=? AND role='assistant' ORDER BY id LIMIT 1",
+            (user_id,),
+        )
+        row = cur.fetchone()
+        if not row:
+            return None
+        try:
+            return json.loads(row["content"])
+        except Exception:
+            return None
 
     def summarize(self, user_id: str, max_chars: int = 200) -> str:
         """Return a simple summary of the conversation history."""

--- a/MCP_119/backend/main.py
+++ b/MCP_119/backend/main.py
@@ -210,6 +210,13 @@ async def execute_sql(request: SQLExecuteRequest):
         )
     if request.user_id:
         context_manager.record(request.user_id, request.query, json.dumps(results))
+    reference = (
+        context_manager.get_first_results(request.user_id)
+        if request.user_id
+        else None
+    )
+    if reference is None:
+        reference = results
     summary = summarize_results(results)
     # Always try to provide a natural language explanation of the results
     prompt_question = (
@@ -218,7 +225,7 @@ async def execute_sql(request: SQLExecuteRequest):
     try:
         answer = answer_generator.generate_answer(
             prompt_question,
-            results,
+            reference,
             model=request.model or "llama3.2:3b",
         )
     except Exception:  # pragma: no cover - depends on environment
@@ -263,13 +270,20 @@ async def ask(request: AskRequest):
 
     if request.user_id:
         context_manager.record(request.user_id, sql, json.dumps(results))
+    reference = (
+        context_manager.get_first_results(request.user_id)
+        if request.user_id
+        else None
+    )
+    if reference is None:
+        reference = results
 
     summary = summarize_results(results)
     answer = ""
     try:
         answer = answer_generator.generate_answer(
             request.question,
-            results,
+            reference,
             model=request.model or "llama3.2:3b",
         )
     except Exception:  # pragma: no cover - depends on environment
@@ -318,13 +332,20 @@ async def chart(request: ChartRequest):
 
     if request.user_id:
         context_manager.record(request.user_id, chart_sql, json.dumps(results))
+    reference = (
+        context_manager.get_first_results(request.user_id)
+        if request.user_id
+        else None
+    )
+    if reference is None:
+        reference = results
 
     summary = summarize_results(results)
     answer = ""
     try:
         answer = answer_generator.generate_answer(
             request.question,
-            results,
+            reference,
             model=request.model or "llama3.2:3b",
         )
     except Exception:  # pragma: no cover - depends on environment


### PR DESCRIPTION
## Summary
- store first query results per user
- use initial results to generate natural language answers

## Testing
- `python -m py_compile MCP_119/backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68773ea582a08323965c89a66224a649