### PR TITLE
Integrate dashboard view

### DIFF
--- a/MCP_119/frontend/home/src/App.js
+++ b/MCP_119/frontend/home/src/App.js
@@ -1,9 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import './App.css';
 import Loader from './Loader';
-import HistorySidebar from './HistorySidebar';
-import ChartView from './ChartView';
-import FinalResponse from './FinalResponse';
+import Dashboard from './Dashboard';
 import { Trash2 } from 'lucide-react';
 
 
@@ -18,7 +16,6 @@ function App() {
   const [error, setError] = useState(null);
   const [models, setModels] = useState([]);
   const [model, setModel] = useState('');
-  const [useChart, setUseChart] = useState(false);
   const [history, setHistory] = useState(() => {
     try {
       return JSON.parse(localStorage.getItem('history')) || [];
@@ -105,39 +102,25 @@ function App() {
     setSummary('');
     setAnswer('');
     try {
-      if (useChart) {
-        const resp = await fetch('/api/chart', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ question: query, model })
-        });
-        if (!resp.ok) throw new Error('Failed to generate chart data');
-        const data = await resp.json();
-        if (data.error) throw new Error(data.error.message || 'Server error');
-        const generatedSql = data.result?.sql || data.sql || '';
-        const results = data.result?.results || data.results || [];
-        const summaryText = data.result?.summary || data.summary || '';
-        const answerText = data.result?.answer || data.answer || '';
+      const resp = await fetch('/api/chart', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question: query, model })
+      });
+      if (!resp.ok) throw new Error('Failed to generate chart data');
+      const data = await resp.json();
+      if (data.error) throw new Error(data.error.message || 'Server error');
+      const generatedSql = data.result?.sql || data.sql || '';
+      const results = data.result?.results || data.results || [];
+      const summaryText = data.result?.summary || data.summary || '';
+      const answerText = data.result?.answer || data.answer || '';
 
-        setSql(generatedSql);
-        setResult(results);
-        setSummary(summaryText);
-        setAnswer(answerText);
+      setSql(generatedSql);
+      setResult(results);
+      setSummary(summaryText);
+      setAnswer(answerText);
 
-        addHistory(query, summaryText, answerText, generatedSql, results, model);
-      } else {
-        const resp = await fetch('/api/sql', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ question: query, model })
-        });
-        if (!resp.ok) throw new Error('Failed to generate SQL');
-        const data = await resp.json();
-        if (data.error) throw new Error(data.error.message || 'Server error');
-        const generatedSql = data.result?.sql || data.sql || '';
-        setSql(generatedSql);
-        await executeSql(generatedSql, query);
-      }
+      addHistory(query, summaryText, answerText, generatedSql, results, model);
     } catch (err) {
       setError(err.message);
     } finally {
@@ -200,14 +183,6 @@ function App() {
               placeholder="輸入你的問題"
               className="border rounded p-2 flex-1"
             />
-            <label className="flex items-center space-x-1">
-              <input
-                type="checkbox"
-                checked={useChart}
-                onChange={(e) => setUseChart(e.target.checked)}
-              />
-              <span>生成圖表</span>
-            </label>
             <button
               type="submit"
               disabled={loading}
@@ -246,55 +221,15 @@ function App() {
             </div>
           )}
 
-          {(Array.isArray(result) && result.length > 0) && (
-            <section className="bg-gray-100 p-4 rounded shadow-inner space-y-4">
-              <h2 className="text-lg font-bold text-gray-700">查詢結果</h2>
-              <div className="overflow-auto max-h-96">
-                <table className="min-w-full border text-sm">
-                  <thead className="bg-gray-100">
-                    <tr>
-                      {Object.keys(result[0]).map((key, idx) => (
-                        <th
-                          key={key}
-                          className={`border px-2 py-1 text-left font-semibold sticky top-0 bg-white ${idx === 0 ? 'left-0 z-10' : ''}`}
-                        >
-                          {key}
-                        </th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {result.map((row, idx) => (
-                      <tr key={idx} className="even:bg-gray-50 hover:bg-gray-100">
-                        {Object.values(row).map((val, i) => (
-                          <td
-                            key={i}
-                            className={`border px-2 py-1 ${i === 0 ? 'bg-white sticky left-0' : ''}`}
-                          >
-                            {String(val)}
-                          </td>
-                        ))}
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </section>
-          )}
-
-          {Array.isArray(result) && result.length > 0 && (
-            <ChartView result={result} />
-          )}
-
-
-          <FinalResponse
+          <Dashboard
+            result={result}
             answer={answer}
             summary={summary}
-            showFallback={Array.isArray(result) && result.length === 0}
+            history={history}
+            clearHistory={clearHistory}
+            openHistory={openHistory}
           />
         </div>
-
-        <HistorySidebar history={history} clearHistory={clearHistory} openHistory={openHistory} />
       </div>
     </div>
   );

--- a/MCP_119/frontend/home/src/Dashboard.js
+++ b/MCP_119/frontend/home/src/Dashboard.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import ChartView from './ChartView';
+import HistorySidebar from './HistorySidebar';
+import FinalResponse from './FinalResponse';
+
+function Dashboard({ result, answer, summary, history, clearHistory, openHistory }) {
+  return (
+    <div className="flex flex-col md:flex-row space-y-4 md:space-y-0 md:space-x-4">
+      <div className="flex-1 space-y-4">
+        {Array.isArray(result) && result.length > 0 && (
+          <section className="bg-gray-100 p-4 rounded shadow-inner space-y-4">
+            <h2 className="text-lg font-bold text-gray-700">查詢結果</h2>
+            <div className="overflow-auto max-h-96">
+              <table className="min-w-full border text-sm">
+                <thead className="bg-gray-100">
+                  <tr>
+                    {Object.keys(result[0]).map((key, idx) => (
+                      <th
+                        key={key}
+                        className={`border px-2 py-1 text-left font-semibold sticky top-0 bg-white ${idx === 0 ? 'left-0 z-10' : ''}`}
+                      >
+                        {key}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {result.map((row, idx) => (
+                    <tr key={idx} className="even:bg-gray-50 hover:bg-gray-100">
+                      {Object.values(row).map((val, i) => (
+                        <td
+                          key={i}
+                          className={`border px-2 py-1 ${i === 0 ? 'bg-white sticky left-0' : ''}`}
+                        >
+                          {String(val)}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+
+        {Array.isArray(result) && result.length > 0 && <ChartView result={result} />}
+
+        <FinalResponse
+          answer={answer}
+          summary={summary}
+          showFallback={Array.isArray(result) && result.length === 0}
+        />
+      </div>
+      <HistorySidebar history={history} clearHistory={clearHistory} openHistory={openHistory} />
+    </div>
+  );
+}
+
+export default Dashboard;


### PR DESCRIPTION
## Summary
- remove chart toggle and always build chart
- add Dashboard component to house table, chart, and history
- update App to use new Dashboard and fetch chart data by default

## Testing
- `npm run build` *(fails: react-scripts not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68774a38d9b08323b01cf458967a232f